### PR TITLE
Moving UseSourceMaps setting to within the Compile setting

### DIFF
--- a/Chutzpah/BatchCompiler/BatchCompilerService.cs
+++ b/Chutzpah/BatchCompiler/BatchCompilerService.cs
@@ -89,7 +89,7 @@ namespace Chutzpah.BatchProcessor
 
                     if (!string.IsNullOrWhiteSpace(file.GeneratedFilePath))
                     {
-                        file.SourceMapFilePath = testSettings.UseSourceMaps ? sourceMapDiscoverer.FindSourceMap(file.GeneratedFilePath) : null;
+                        file.SourceMapFilePath = testSettings.Compile.UseSourceMaps ? sourceMapDiscoverer.FindSourceMap(file.GeneratedFilePath) : null;
                     }
                 }
             }

--- a/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
+++ b/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
@@ -149,7 +149,7 @@ namespace Chutzpah.Coverage
                 else
                 {
                     newKey = referencedFile.Path;
-                    if (referencedFile.SourceMapFilePath != null && testContext.TestFileSettings.UseSourceMaps)
+                    if (referencedFile.SourceMapFilePath != null && testContext.TestFileSettings.Compile != null && testContext.TestFileSettings.Compile.UseSourceMaps)
                     {
                         filePath = referencedFile.Path;
                     }
@@ -160,7 +160,7 @@ namespace Chutzpah.Coverage
                     string[] sourceLines = fileSystem.GetLines(filePath);
                     int?[] lineExecutionCounts = entry.Value;
 
-                    if (testContext.TestFileSettings.UseSourceMaps && referencedFile != null && referencedFile.SourceMapFilePath != null)
+                    if (testContext.TestFileSettings.Compile != null && testContext.TestFileSettings.Compile.UseSourceMaps && referencedFile != null && referencedFile.SourceMapFilePath != null)
                     {
                         lineExecutionCounts = this.lineCoverageMapper.GetOriginalFileLineExecutionCounts(entry.Value, sourceLines.Length, referencedFile.SourceMapFilePath);
                     }

--- a/Chutzpah/Models/BatchCompileConfiguration.cs
+++ b/Chutzpah/Models/BatchCompileConfiguration.cs
@@ -75,5 +75,11 @@ namespace Chutzpah.Models
         /// code is using then you can turn this off. Ideally you can tell Chutzpah about these and then set this to be more performant
         /// </summary>
         public bool SkipIfUnchanged { get; set; }
+
+        /// <summary>
+        /// Configures whether .map files should be loaded (if available) to convert under-test JS
+        /// line numbers to those of their original source files.
+        /// </summary>
+        public bool UseSourceMaps { get; set; }
     }
 }

--- a/Chutzpah/Models/ChutzpahTestSettingsFile.cs
+++ b/Chutzpah/Models/ChutzpahTestSettingsFile.cs
@@ -175,12 +175,6 @@ namespace Chutzpah.Models
         /// </summary>
         public ICollection<TransformConfig> Transforms { get; set; }
 
-        /// <summary>
-        /// Configures whether .map files should be loaded (if available) to convert under-test JS
-        /// line numbers to those of their original source files.
-        /// </summary>
-        public bool UseSourceMaps { get; set; }
-
         #region Deprecated Properties. These are part of the old compile support Chutzpah had where it would embed the compiler. Please use compile setting now
 
         /// <summary>

--- a/Facts.Integration/JS/Test/Coverage/SourceMaps/chutzpah.json
+++ b/Facts.Integration/JS/Test/Coverage/SourceMaps/chutzpah.json
@@ -1,6 +1,6 @@
 {
-    "UseSourceMaps": true,
     "Compile": {
+        "UseSourceMaps": true,
         "Mode": "External",
         "Extensions": [ ".ts" ],
         "ExtensionsWithNoOutput": [ ".d.ts" ]

--- a/Facts/Library/BatchCompilerServiceFacts.cs
+++ b/Facts/Library/BatchCompilerServiceFacts.cs
@@ -151,7 +151,7 @@ namespace Chutzpah.Facts
             var context = service.BuildContext();
             context.TestFileSettings.Compile.Extensions = new[] { ".ts" };
             context.TestFileSettings.Compile.SourceDirectory = @"C:\other";
-            context.TestFileSettings.UseSourceMaps = true;
+            context.TestFileSettings.Compile.UseSourceMaps = true;
             context.ReferencedFiles.Add(new ReferencedFile { Path = @"C:\other\a.ts" });
             service.Mock<IFileSystemWrapper>().SetupSequence(x => x.FileExists(It.Is<string>(f => f != null && f.EndsWith(".js"))))
                 .Returns(false)
@@ -170,7 +170,7 @@ namespace Chutzpah.Facts
             var context = service.BuildContext();
             context.TestFileSettings.Compile.Extensions = new[] { ".ts" };
             context.TestFileSettings.Compile.SourceDirectory = @"C:\other";
-            context.TestFileSettings.UseSourceMaps = false;
+            context.TestFileSettings.Compile.UseSourceMaps = false;
             context.ReferencedFiles.Add(new ReferencedFile { Path = @"C:\other\a.ts" });
             service.Mock<IFileSystemWrapper>().SetupSequence(x => x.FileExists(It.Is<string>(f => f != null && f.EndsWith(".js"))))
                 .Returns(false)

--- a/Facts/Library/Coverage/BlanketJsCoverageEngineFacts.cs
+++ b/Facts/Library/Coverage/BlanketJsCoverageEngineFacts.cs
@@ -58,7 +58,10 @@ namespace Chutzpah.Facts.Library.Coverage
             {
                 TestFileSettings = new ChutzpahTestSettingsFile
                 {
-                    UseSourceMaps = true,
+                    Compile = new BatchCompileConfiguration
+                    {
+                        UseSourceMaps = true,
+                    }
                 },
                 ReferencedFiles = new[] 
                 { 
@@ -130,7 +133,7 @@ namespace Chutzpah.Facts.Library.Coverage
         public void DeserializeCoverageObject_UsesGeneratedSource_WhenSourceMapsDisabled()
         {
             var testContext = GetContext();
-            testContext.TestFileSettings.UseSourceMaps = false;
+            testContext.TestFileSettings.Compile.UseSourceMaps = false;
             var coverageDict = GetLineExecutions();
             var mapperOutput = new int?[] { 1, null };
             var underTest = new TestableCoverageEngine(coverageDict, mapperOutput);
@@ -148,7 +151,7 @@ namespace Chutzpah.Facts.Library.Coverage
         public void DeserializeCoverageObject_SkipsLineCoverageMapper_IfSettingsDisabled()
         {
             var testContext = GetContext();
-            testContext.TestFileSettings.UseSourceMaps = false;
+            testContext.TestFileSettings.Compile.UseSourceMaps = false;
 
             var underTest = new TestableCoverageEngine(GetLineExecutions());
             underTest.ClassUnderTest.DeserializeCoverageObject("the json", testContext);


### PR DESCRIPTION
Per discussion on #316, moving UseSourceMaps setting to Compile section rather than having it be a top-level configuration setting.