### PR TITLE
Resolve dependency issue when .Net 4.5.1 or > is present

### DIFF
--- a/VS2012/source.extension.vsixmanifest
+++ b/VS2012/source.extension.vsixmanifest
@@ -18,7 +18,7 @@
     <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Ultimate" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
   </Dependencies>
   <Assets>


### PR DESCRIPTION
The installation was failing with an error "The extension 'Chutzpah Test Adapter for the Test Explorer' requires a version of the .NET Framework that is not installed." when .Net 4.5.1 was installed. Change allows 4.5 or greater to be present.