### PR TITLE
openInBrowser enhancement

### DIFF
--- a/Chutzpah/Chutzpah.csproj
+++ b/Chutzpah/Chutzpah.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Transformers\SummaryTransformerProvider.cs" />
     <Compile Include="Transformers\TransformProcessor.cs" />
     <Compile Include="Transformers\TrxXmlTransformer.cs" />
+    <Compile Include="Utility\BrowserPathHelper.cs" />
     <Compile Include="Utility\Hasher.cs" />
     <Compile Include="Utility\IHasher.cs" />
     <Compile Include="Wrappers\EnvironmentWrapper.cs" />

--- a/Chutzpah/IProcessHelper.cs
+++ b/Chutzpah/IProcessHelper.cs
@@ -5,7 +5,7 @@ namespace Chutzpah
 {
     public interface IProcessHelper
     {
-        void LaunchFileInBrowser(string file);
+        void LaunchFileInBrowser(string file, string browserName);
         ProcessResult<T> RunExecutableAndProcessOutput<T>(string exePath, string arguments, Func<ProcessStream, T> streamProcessor) where T : class;
         BatchCompileResult RunBatchCompileProcess(BatchCompileConfiguration compileConfiguration);
     }

--- a/Chutzpah/ProcessHelper.cs
+++ b/Chutzpah/ProcessHelper.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Threading;
 using Chutzpah.Models;
+using Chutzpah.Utility;
 using Chutzpah.Wrappers;
+using Microsoft.Win32;
 
 namespace Chutzpah
 {
@@ -104,12 +107,24 @@ namespace Chutzpah
 
         }
 
-        public void LaunchFileInBrowser(string file)
+        public void LaunchFileInBrowser(string file, string browserName)
         {
+            var browserAppPath = BrowserPathHelper.GetBrowserPath(browserName);
+
             var startInfo = new ProcessStartInfo();
-            startInfo.UseShellExecute = true;
-            startInfo.Verb = "Open";
-            startInfo.FileName = file;
+            if (!string.IsNullOrEmpty(browserAppPath))
+            {
+                startInfo.UseShellExecute = true;
+                startInfo.FileName = browserAppPath;
+                startInfo.Arguments = file;
+            }
+            else
+            {
+                startInfo.UseShellExecute = true;
+                startInfo.Verb = "Open";
+                startInfo.FileName = file;
+            }
+
             Process.Start(startInfo);
         }
     }

--- a/Chutzpah/TestOptions.cs
+++ b/Chutzpah/TestOptions.cs
@@ -24,10 +24,15 @@ namespace Chutzpah
         }
 
         /// <summary>
-        /// Whether or not to launch the tests in the default browser
+        /// Whether or not to launch the tests in the browser
         /// </summary>
         public bool OpenInBrowser { get; set; }
 
+        /// <summary>
+        /// The name of browser which will be opened when OpenInBrowser is enabled, this value is optional
+        /// </summary>
+        public string BrowserName { get; set; }
+        
         /// <summary>
         /// The time to wait for the tests to compelte in milliseconds
         /// </summary>

--- a/Chutzpah/TestRunner.cs
+++ b/Chutzpah/TestRunner.cs
@@ -296,7 +296,7 @@ namespace Chutzpah
                                 "Launching test harness '{0}' for file '{1}' in a browser",
                                 testContext.TestHarnessPath,
                                 testContext.FirstInputTestFile);
-                            process.LaunchFileInBrowser(testContext.TestHarnessPath);
+                            process.LaunchFileInBrowser(testContext.TestHarnessPath, options.BrowserName);
                         }
                         else
                         {

--- a/Chutzpah/Utility/BrowserPathHelper.cs
+++ b/Chutzpah/Utility/BrowserPathHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Configuration;
 using Microsoft.Win32;
 
@@ -15,14 +16,21 @@ namespace Chutzpah.Utility
         {
             var browserPath = string.Empty;
 
-            if (!string.IsNullOrEmpty(browserName))
+            try
             {
-                browserPath = GetBrowserPathFromRegistry(browserName);
-            }
+                if (!string.IsNullOrEmpty(browserName))
+                {
+                    browserPath = GetBrowserPathFromRegistry(browserName);
+                }
 
-            if (string.IsNullOrEmpty(browserPath))
+                if (string.IsNullOrEmpty(browserPath))
+                {
+                    browserPath = GetSystemDefaultBrowser();
+                }
+            }
+            catch (Exception e)
             {
-                browserPath = GetSystemDefaultBrowser();
+                ChutzpahTracer.TraceError(e, "Unable to read browser path from registry");
             }
 
             return browserPath;

--- a/Chutzpah/Utility/BrowserPathHelper.cs
+++ b/Chutzpah/Utility/BrowserPathHelper.cs
@@ -1,0 +1,119 @@
+﻿using System.IO;
+using System.Net.Configuration;
+using Microsoft.Win32;
+
+namespace Chutzpah.Utility
+{
+    public class BrowserPathHelper
+    {
+        private const string BrowserIERegPath = "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\IEXPLORE.EXE";
+        private const string BrowserChromeRegPath = "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Chrome.EXE";
+        private const string BrowserFirefoxRegPath = "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Firefox.exe";
+        private const string DefaultBrowserProdIdPath = "Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice";
+
+        public static string GetBrowserPath(string browserName)
+        {
+            var browserPath = string.Empty;
+
+            if (!string.IsNullOrEmpty(browserName))
+            {
+                browserPath = GetBrowserPathFromRegistry(browserName);
+            }
+
+            if (string.IsNullOrEmpty(browserPath))
+            {
+                browserPath = GetSystemDefaultBrowser();
+            }
+
+            return browserPath;
+        }
+
+        private static string GetBrowserPathFromRegistry(string browserName)
+        {
+            string browserPath = null;
+            bool hasRegEntry = false;
+            switch (browserName.ToLower())
+            {
+                case "ie":
+                    hasRegEntry = TryRetrieveRegistryKeyValue(Registry.LocalMachine, BrowserIERegPath, null, out browserPath);
+                    break;
+                case "chrome":
+                    hasRegEntry = TryRetrieveRegistryKeyValue(Registry.LocalMachine, BrowserChromeRegPath, null, out browserPath);
+                    break;
+                case "firefox":
+                    hasRegEntry = TryRetrieveRegistryKeyValue(Registry.LocalMachine, BrowserFirefoxRegPath, null, out browserPath);
+                    break;
+                default:
+                    break;
+            }
+
+            if (hasRegEntry && File.Exists(browserPath))
+            {
+                return browserPath;
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string GetSystemDefaultBrowser()
+        {
+            string defaultBrowserProgId;
+            string defaultBrowserCommandPath;
+            string trimmedDefaultBrowserCommandPath;
+
+            if (TryRetrieveRegistryKeyValue(Registry.CurrentUser, DefaultBrowserProdIdPath, "ProgId", out defaultBrowserProgId) &&
+                TryRetrieveRegistryKeyValue(Registry.LocalMachine, "Software\\Classes\\" + defaultBrowserProgId + "\\shell\\open\\command", null, out defaultBrowserCommandPath) &&
+                TrimRegistryCommandPath(defaultBrowserCommandPath, out trimmedDefaultBrowserCommandPath) &&
+                File.Exists(trimmedDefaultBrowserCommandPath))
+            {
+                return trimmedDefaultBrowserCommandPath;
+            }
+
+            return string.Empty;
+        }
+
+        private static bool TryRetrieveRegistryKeyValue(RegistryKey parentKey, string registryKeyPath, string name, out string registryValue)
+        {
+            var registryKey = parentKey.OpenSubKey(registryKeyPath, false);
+            registryValue = null;
+
+            if (registryKey != null)
+            {
+                var value = registryKey.GetValue(name);
+                if (value != null)
+                {
+                    registryValue = value.ToString();
+                }
+
+                registryKey.Close();
+            }
+
+            return !string.IsNullOrEmpty(registryValue);
+        }
+
+        private static bool TrimRegistryCommandPath(string commandFilePath, out string trimmedCommandFilePath)
+        {
+            trimmedCommandFilePath = null;
+
+            commandFilePath = commandFilePath.ToLower().Replace("\"", string.Empty);
+
+            if (!commandFilePath.EndsWith("exe"))
+            {
+                var indexOfExe = commandFilePath.LastIndexOf(".exe");
+
+                if (indexOfExe > 0)
+                {
+                    trimmedCommandFilePath = commandFilePath.Substring(0, indexOfExe + 4);
+                }
+            }
+            else
+            {
+                trimmedCommandFilePath = commandFilePath;
+            }
+
+            return !string.IsNullOrEmpty(trimmedCommandFilePath);
+        }
+    }
+}

--- a/ConsoleRunner/CommandLine.cs
+++ b/ConsoleRunner/CommandLine.cs
@@ -61,6 +61,8 @@ namespace Chutzpah
         
         public string CoverageExcludePatterns { get; protected set; }
 
+        public string BrowserName { get; protected set; }
+
         private static void GuardNoOptionValue(KeyValuePair<string, string> option)
         {
             if (option.Value != null)
@@ -115,7 +117,7 @@ namespace Chutzpah
                 }
                 else if (optionName == "/openinbrowser")
                 {
-                    GuardNoOptionValue(option);
+                    AddBrowserName(option.Value);
                     OpenInBrowser = true;
                 }
                 else if (optionName == "/silent")
@@ -235,6 +237,23 @@ namespace Chutzpah
             }
 
             TimeOutMilliseconds = timeout;
+        }
+
+        private void AddBrowserName(string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                if (value.Equals("ie", StringComparison.InvariantCultureIgnoreCase) ||
+                    value.Equals("chrome", StringComparison.InvariantCultureIgnoreCase) ||
+                    value.Equals("firefox", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    BrowserName = value;
+                }
+                else
+                {
+                    throw new ArgumentException("invalid browser name, expecting either ie, chrome or firefox");
+                }
+            }
         }
 
         private void AddFileOption(string file)

--- a/ConsoleRunner/Program.cs
+++ b/ConsoleRunner/Program.cs
@@ -138,6 +138,7 @@ namespace Chutzpah
                 var testOptions = new TestOptions
                     {
                         OpenInBrowser = commandLine.OpenInBrowser,
+                        BrowserName = commandLine.BrowserName,
                         TestFileTimeoutMilliseconds = commandLine.TimeOutMilliseconds,
                         MaxDegreeOfParallelism = commandLine.Parallelism,
                         ChutzpahSettingsFileEnvironments = commandLine.SettingsFileEnvironments,


### PR DESCRIPTION
Enhance openInbrowser parameter to accept an optional browseranme
value. such as ie, chrome and firefox. Chutzpah will try to open the
test page in the psecified browser. If browser name is not provided,
Chutzpah will try to open the test page using the default browser. If no
default browser is found, Chutzpah will open the test page using the
default app for html file