### PR TITLE
Adding Mark of the Web to prevent scripts blocking in Internet Explorer

### DIFF
--- a/Chutzpah/TestFiles/Jasmine/v1/jasmine.html
+++ b/Chutzpah/TestFiles/Jasmine/v1/jasmine.html
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿<!-- saved from url=(0014)about:internet -->
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />

--- a/Chutzpah/TestFiles/Jasmine/v2/jasmine.html
+++ b/Chutzpah/TestFiles/Jasmine/v2/jasmine.html
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿<!-- saved from url=(0014)about:internet -->
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />

--- a/Chutzpah/TestFiles/Mocha/mocha.html
+++ b/Chutzpah/TestFiles/Mocha/mocha.html
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿<!-- saved from url=(0014)about:internet -->
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />

--- a/Chutzpah/TestFiles/QUnit/qunit.html
+++ b/Chutzpah/TestFiles/QUnit/qunit.html
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿<!-- saved from url=(0014)about:internet -->
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
I've added [Mark of the Web](https://msdn.microsoft.com/en-us/library/ms537628.aspx) to harness files to make IE think that file is serve from Internet instead of file system with for some reasons have more restrictions. Please follow the link for details.

I find no way to unit test this, but I have tested it locally and it works for me.
Hope you find this fix useful.