### PR TITLE
Blanket Coverage: Only proceed to map to local path when URI scheme is file

### DIFF
--- a/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
+++ b/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
@@ -127,6 +127,9 @@ namespace Chutzpah.Coverage
             foreach (var entry in data)
             {
                 Uri uri = new Uri(entry.Key, UriKind.RelativeOrAbsolute);
+                if (uri.Scheme != "file")
+                    continue;
+
                 if (!uri.IsAbsoluteUri)
                 {
                     // Resolve against the test file path.


### PR DESCRIPTION
I believe the chutzpah.json config file uses the References to include files that are local that should be loaded for testing. The fellow that setup our TypeScript tests also included http:// references to files that were needed (mostly angular related). I found that this broke when used with the /codecoverage option because it tries to determine the LocalPath of the URI. This change makes sure that only file based URIs are checked for their LocalPath. 