### PR TITLE
VS Debugger Support (2nd attempt)

### DIFF
--- a/Chutzpah/Chutzpah.csproj
+++ b/Chutzpah/Chutzpah.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Models\ChutzpahSettingsFileEnvironments.cs" />
     <Compile Include="Models\SettingsFilePath.cs" />
     <Compile Include="Models\SettingsFileTestPath.cs" />
+    <Compile Include="Models\TestLaunchMode.cs" />
     <Compile Include="Models\TransformConfig.cs" />
     <Compile Include="Models\vstsModel\vstst.cs">
       <DependentUpon>vstst.xsd</DependentUpon>

--- a/Chutzpah/Chutzpah.csproj
+++ b/Chutzpah/Chutzpah.csproj
@@ -164,8 +164,10 @@
     <Compile Include="Transformers\TransformProcessor.cs" />
     <Compile Include="Transformers\TrxXmlTransformer.cs" />
     <Compile Include="Utility\BrowserPathHelper.cs" />
+    <Compile Include="Utility\ComHelpers.cs" />
     <Compile Include="Utility\Hasher.cs" />
     <Compile Include="Utility\IHasher.cs" />
+    <Compile Include="Utility\ProcessExtensions.cs" />
     <Compile Include="Wrappers\EnvironmentWrapper.cs" />
     <Compile Include="Wrappers\FileSystemWrapper.cs" />
     <Compile Include="Wrappers\HtmlUtility.cs" />

--- a/Chutzpah/Chutzpah.csproj
+++ b/Chutzpah/Chutzpah.csproj
@@ -81,6 +81,7 @@
     <Compile Include="FileProcessors\LineNumberProcessor.cs" />
     <Compile Include="FileProcessors\MochaInterfaceDetectionProcessor.cs" />
     <Compile Include="FileProcessors\SourceMapDiscoverer.cs" />
+    <Compile Include="ITestLauncher.cs" />
     <Compile Include="Models\BatchCompileConfiguration.cs" />
     <Compile Include="Models\BatchCompileResult.cs" />
     <Compile Include="Models\ChutzpahSettingsFileEnvironments.cs" />

--- a/Chutzpah/ITestLauncher.cs
+++ b/Chutzpah/ITestLauncher.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Chutzpah.Models;
+
+namespace Chutzpah
+{
+    /// <summary>
+    /// Describes a custom test launch service.
+    /// </summary>
+    public interface ITestLauncher
+    {
+        void LaunchTest(TestContext testContext);
+        void CleanupTest(TestContext testContext);
+    }
+}

--- a/Chutzpah/Models/TestLaunchMode.cs
+++ b/Chutzpah/Models/TestLaunchMode.cs
@@ -1,0 +1,23 @@
+﻿namespace Chutzpah.Models
+{
+    /// <summary>
+    /// Describes different ways in which a test can be launched.
+    /// </summary>
+    public enum TestLaunchMode
+    {
+        /// <summary>
+        /// Launch the test in a headless browser.
+        /// </summary>
+        HeadlessBrowser,
+        
+        /// <summary>
+        /// Launch the test in a full web browser.
+        /// </summary>
+        FullBrowser,
+
+        /// <summary>
+        /// Launch the test via a/the ITestLauncher object.
+        /// </summary>
+        Custom,
+    }
+}

--- a/Chutzpah/TestOptions.cs
+++ b/Chutzpah/TestOptions.cs
@@ -24,14 +24,20 @@ namespace Chutzpah
         }
 
         /// <summary>
-        /// Whether or not to launch the tests in the browser
+        /// Describes the ways in which the test is to be launched.
         /// </summary>
-        public bool OpenInBrowser { get; set; }
+        public TestLaunchMode TestLaunchMode { get; set; }
 
         /// <summary>
-        /// The name of browser which will be opened when OpenInBrowser is enabled, this value is optional
+        /// The name of browser which will be opened when TestLaunchMode.FullBrowser is set, this value is optional
         /// </summary>
         public string BrowserName { get; set; }
+        
+        /// <summary>
+        /// Test launch object implementing the Custom test launch logic.
+        /// Required when TestLaunchMode == TestLaunchMode.Custom.
+        /// </summary>
+        public ITestLauncher CustomTestLauncher { get; set; }
         
         /// <summary>
         /// The time to wait for the tests to compelte in milliseconds

--- a/Chutzpah/Utility/ComHelpers.cs
+++ b/Chutzpah/Utility/ComHelpers.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace Chutzpah.Utility
+{
+    [
+        ComImport, 
+        Guid("00000016-0000-0000-C000-000000000046"), 
+        InterfaceType(ComInterfaceType.InterfaceIsIUnknown)
+    ]
+    internal interface IMessageFilter
+    {
+        [PreserveSig]
+        int HandleInComingCall(
+            int dwCallType,
+            IntPtr hTaskCaller,
+            int dwTickCount,
+            IntPtr lpInterfaceInfo);
+
+        [PreserveSig]
+        int RetryRejectedCall(
+            IntPtr hTaskCallee,
+            int dwTickCount,
+            int dwRejectType);
+
+        [PreserveSig]
+        int MessagePending(
+            IntPtr hTaskCallee,
+            int dwTickCount,
+            int dwPendingType);
+    }
+
+    public class ResilientMessageFilter : IMessageFilter
+    {
+
+    #region IMessageFilter Members
+
+        int IMessageFilter.HandleInComingCall(
+            int dwCallType,
+            IntPtr hTaskCaller, 
+            int dwTickCount, 
+            IntPtr lpInterfaceInfo)
+        {
+        // This method applicable to calls arriving in this (STA) thd.
+        //
+            return /*SERVERCALL_ISHANDLED*/0;
+        }
+
+        int IMessageFilter.RetryRejectedCall(
+            IntPtr hTaskCallee, 
+            int dwTickCount, 
+            int dwRejectType)
+        {
+            // If server asked us to retry later...tell COM to retry later, with any delay
+            // according to current dwTickCount.
+            if (dwRejectType == /*SERVERCALL_RETRYLATER*/2
+                && dwTickCount < 10000) { // timeout on retrying after 10s
+                Debug.Assert(dwTickCount != -1);
+                return dwTickCount / 10 +1;
+            }
+            // Owise our call to the server apartment was rejected by the server so tell COM
+            // we're happy to abandon.
+            else {
+                return -1; }
+        }
+
+        int IMessageFilter.MessagePending(
+            IntPtr hTaskCallee,
+            int dwTickCount, 
+            int dwPendingType)
+        {
+        // Called when windows message arrives while this (STA) thd is calling out 
+        // to another apartment.
+        //
+            return /*PENDINGMSG_WAITDEFPROCESS*/2;
+        }
+
+    #endregion
+
+    }
+
+    /// <summary>
+    /// Helper class for establishing the registration of the ResilientMessageFilter class
+    /// for a limited scope. To be used with the using() pattern.
+    /// </summary>
+    public class ResilientMessageFilterScope : IDisposable
+    {
+        [DllImport("Ole32.dll")]
+        private static extern int CoRegisterMessageFilter(
+            IMessageFilter newFilter, 
+            out IMessageFilter orgFilter);
+
+        IMessageFilter orgFilter = null;
+
+        public ResilientMessageFilterScope()
+        {
+            IMessageFilter newFilter = new ResilientMessageFilter();
+            CoRegisterMessageFilter(newFilter, out orgFilter);
+        }
+
+        public void Dispose()
+        {
+            IMessageFilter prevFilter = null;
+            CoRegisterMessageFilter(orgFilter, out prevFilter);
+        }
+    }
+}

--- a/Chutzpah/Utility/ProcessExtensions.cs
+++ b/Chutzpah/Utility/ProcessExtensions.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace Chutzpah.Utility
+{
+    public static class ProcessExtensions
+    {
+        [Flags]
+        public enum ThreadAccess : int
+        {
+            TERMINATE = (0x0001),
+            SUSPEND_RESUME = (0x0002),
+            GET_CONTEXT = (0x0008),
+            SET_CONTEXT = (0x0010),
+            SET_INFORMATION = (0x0020),
+            QUERY_INFORMATION = (0x0040),
+            SET_THREAD_TOKEN = (0x0080),
+            IMPERSONATE = (0x0100),
+            DIRECT_IMPERSONATION = (0x0200)
+        }
+
+        [Flags]
+        public enum ProcessAccessFlags : uint
+        {
+            All = 0x001F0FFF,
+            Terminate = 0x00000001,
+            CreateThread = 0x00000002,
+            VirtualMemoryOperation = 0x00000008,
+            VirtualMemoryRead = 0x00000010,
+            VirtualMemoryWrite = 0x00000020,
+            DuplicateHandle = 0x00000040,
+            CreateProcess = 0x000000080,
+            SetQuota = 0x00000100,
+            SetInformation = 0x00000200,
+            QueryInformation = 0x00000400,
+            QueryLimitedInformation = 0x00001000,
+            Synchronize = 0x00100000
+        }
+
+        // [StructLayout(LayoutKind.Sequential)]
+        private struct PROCESS_BASIC_INFORMATION
+        {
+            public int ExitStatus;
+            public int PebBaseAddress;
+            public int AffinityMask;
+            public int BasePriority;
+            public uint UniqueProcessId;
+            public uint InheritedFromUniqueProcessId;
+        }
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr OpenProcess(
+             ProcessAccessFlags processAccess,
+             bool bInheritHandle,
+             int processId);
+        [DllImport("kernel32.dll")]
+        static extern IntPtr OpenThread(
+            ThreadAccess dwDesiredAccess, 
+            bool bInheritHandle, 
+            uint dwThreadId);
+        [DllImport("kernel32.dll", SetLastError=true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool CloseHandle(
+            IntPtr hObject);
+        [DllImport("kernel32.dll")]
+        static extern uint SuspendThread(
+            IntPtr hThread);
+        [DllImport("kernel32.dll")]
+        static extern int ResumeThread(
+            IntPtr hThread);
+        [DllImport("ntdll.dll")]
+        static extern int NtQueryInformationProcess(
+            IntPtr hProcess,
+            int processInformationClass /* 0 */,
+            ref PROCESS_BASIC_INFORMATION processBasicInformation,
+            uint processInformationLength,
+            out uint returnLength);
+
+        /// <summary>
+        /// Helper to suspened all threads in the specified process.
+        /// </summary>
+        public static void Suspend(this Process process)
+        {
+            foreach (ProcessThread thread in process.Threads)
+            {
+                var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);
+                if (pOpenThread != IntPtr.Zero) {
+                    SuspendThread(pOpenThread);
+                    CloseHandle(pOpenThread);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper to resume any/all suspended threads in the specified process.
+        /// </summary>
+        public static void Resume(this Process process)
+        {
+            foreach (ProcessThread thread in process.Threads)
+            {
+                var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);
+                if (pOpenThread != IntPtr.Zero) {
+                    ResumeThread(pOpenThread);
+                    CloseHandle(pOpenThread);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper that returns the first process in the collection of system processes
+        /// that is identified as a child of the specified process.
+        /// </summary>
+        public static Process FindFirstChildProcessOf(int subjectProcessId)
+        {
+            // Retrieve all processes on the system
+            Process[] processes = Process.GetProcesses();
+            foreach (Process p in processes)
+            {
+                // Get some basic information about the process
+                PROCESS_BASIC_INFORMATION processInfoB = new PROCESS_BASIC_INFORMATION();
+                try
+                {
+                    uint bytesWritten;
+                    int ntStatus = NtQueryInformationProcess(
+                        p.Handle,
+                        0, 
+                        ref processInfoB, 
+                        (uint)Marshal.SizeOf(processInfoB),
+                        out bytesWritten); // == 0 is OK
+                    if (0 != ntStatus) { // fail?
+                        continue; }
+                    // Is it a child process of the subject process?
+                    if (processInfoB.InheritedFromUniqueProcessId == subjectProcessId) {
+                        return p; }
+                }
+                catch (Exception /* ex */)
+                {
+                    // Ignore, most likely 'Access Denied'
+                }
+            }
+            return null; 
+        }
+
+        /// <summary>
+        /// Helper that tests process parent-child inheritance.
+        /// </summary>
+        /// <param name="matchSame">Value to return if/when process ids are the same.</param>
+        public static bool IsProcessAAncestorOfProcessB(
+            int processId_A, 
+            int processId_B, 
+            bool matchSame = true,
+            int maxHops = int.MaxValue)
+        {
+            if (processId_A == processId_B) {
+                return matchSame; }
+            // Get process handle from the process id.
+            //Process pB = Process.GetProcessById(processId_B); // This throws if process not found, which is undesirable.
+            var hProcess = OpenProcess(ProcessAccessFlags.QueryInformation, false, processId_B);
+            if (hProcess == IntPtr.Zero) {
+                return false; }
+            // Get info about the process.
+            PROCESS_BASIC_INFORMATION processInfoB = new PROCESS_BASIC_INFORMATION();
+            uint bytesWritten;
+            int ntStatus = NtQueryInformationProcess(
+                hProcess,
+                0, 
+                ref processInfoB, 
+                (uint)Marshal.SizeOf(processInfoB),
+                out bytesWritten); // == 0 is OK
+            CloseHandle(hProcess);
+            if (0 != ntStatus) {
+                Debug.Assert(false);
+                return false; }
+            // Does B directly inherit from A?
+            if (processInfoB.InheritedFromUniqueProcessId == processId_A) {
+                return true; }
+            // Optionally recurse up the hierarchy.
+            if (maxHops > 0) {
+                if (processInfoB.InheritedFromUniqueProcessId != 0) {
+                    return IsProcessAAncestorOfProcessB(
+                        processId_A, 
+                        (int)processInfoB.InheritedFromUniqueProcessId, 
+                        matchSame,
+                        maxHops -1); }
+            }
+            // No match.
+            return false;
+        }
+    }
+}

--- a/ConsoleRunner/Program.cs
+++ b/ConsoleRunner/Program.cs
@@ -139,7 +139,7 @@ namespace Chutzpah
 
                 var testOptions = new TestOptions
                     {
-                        OpenInBrowser = commandLine.OpenInBrowser,
+                        TestLaunchMode = commandLine.OpenInBrowser ? TestLaunchMode.FullBrowser : TestLaunchMode.HeadlessBrowser,
                         BrowserName = commandLine.BrowserName,
                         TestFileTimeoutMilliseconds = commandLine.TimeOutMilliseconds,
                         MaxDegreeOfParallelism = commandLine.Parallelism,

--- a/Facts/Library/TestRunnerFacts.cs
+++ b/Facts/Library/TestRunnerFacts.cs
@@ -351,7 +351,7 @@ namespace Chutzpah.Facts
                 runner.Mock<IFileProbe>().Setup(x => x.FindFilePath(@"path\tests.html")).Returns(@"D:\path\tests.html");
                 runner.Mock<IFileProbe>().Setup(x => x.FindFilePath("testRunner.js")).Returns("runner.js");
 
-                TestCaseSummary res = runner.ClassUnderTest.RunTests(@"path\tests.html", new TestOptions { OpenInBrowser = true });
+                TestCaseSummary res = runner.ClassUnderTest.RunTests(@"path\tests.html", new TestOptions { TestLaunchMode = TestLaunchMode.FullBrowser });
 
                 runner.Mock<IProcessHelper>().Verify(x => x.LaunchFileInBrowser(@"D:\harnessPath.html", null));
             }
@@ -484,7 +484,7 @@ namespace Chutzpah.Facts
                 runner.Mock<IFileProbe>().Setup(x => x.FindFilePath(@"path\tests.html")).Returns(@"D:\path\tests.html");
                 runner.Mock<IFileProbe>().Setup(x => x.FindFilePath(TestRunner.TestRunnerJsName)).Returns("jsPath");
 
-                TestCaseSummary res = runner.ClassUnderTest.RunTests(@"path\tests.html", new TestOptions { OpenInBrowser = true });
+                TestCaseSummary res = runner.ClassUnderTest.RunTests(@"path\tests.html", new TestOptions { TestLaunchMode = TestLaunchMode.FullBrowser });
 
                 runner.Mock<ITestContextBuilder>().Verify(x => x.CleanupContext(context), Times.Never());
             }

--- a/VS.Common/DteHelpers.cs
+++ b/VS.Common/DteHelpers.cs
@@ -103,7 +103,6 @@ namespace Chutzpah.VS.Common
         /// </summary>
         /// <param name="subjectProcessId">Id of the process to be debugged.</param>
         /// <param name="debugEngine">Name of the debugger script engine to use e.g. "script" or "native" or "managed".</param>
-/*
         public static void DebugAttachToProcess(int subjectProcessId, string debugEngine)
         {
             // Register COM message filter on this thd to enforce a call retry policy
@@ -128,6 +127,5 @@ namespace Chutzpah.VS.Common
                 }
             }
         }
- */
     }
 }

--- a/VS.Common/DteHelpers.cs
+++ b/VS.Common/DteHelpers.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using Chutzpah.Utility;
+
+namespace Chutzpah.VS.Common
+{
+    public class DteHelpers
+    {
+        [DllImport("ole32.dll")]
+        private static extern int CreateBindCtx(uint reserved, out IBindCtx ppbc);
+ 
+        private static Regex s_regex_dteMoniker = new Regex(@"!VisualStudio\.DTE\.(?:\d|\.)+:(\d+)", RegexOptions.CultureInvariant);
+            // Regex for matching the VS DTE moniker as stored in the COM running object table.
+            // Note the process id suffix to the string which we extract as capture group 1.
+            // Example target: "!VisualStudio.DTE.11.0:11944"
+
+        /// <summary>
+        /// Returns collection of any/all EnvDTE.DTE instances running on the machine.
+        /// http://blogs.msdn.com/b/kirillosenkov/archive/2011/08/10/how-to-get-dte-from-visual-studio-process-id.aspx
+        /// </summary>
+        /// <returns>Collection of EnvDTE.DTE instances keyed by the ID of the process running the DTE.</returns>
+        public static Dictionary<int, EnvDTE.DTE> GetAllDTEs()
+        {
+            Dictionary<int, EnvDTE.DTE> dtes = new Dictionary<int,EnvDTE.DTE>();
+ 
+            IBindCtx bindCtx = null;
+            IRunningObjectTable rot = null;
+            IEnumMoniker enumMonikers = null;
+ 
+            try
+            {
+                Marshal.ThrowExceptionForHR(CreateBindCtx(reserved: 0, ppbc: out bindCtx));
+                bindCtx.GetRunningObjectTable(out rot);
+                rot.EnumRunning(out enumMonikers);
+ 
+                IMoniker[] moniker = new IMoniker[1];
+                IntPtr numberFetched = IntPtr.Zero;
+                while (enumMonikers.Next(1, moniker, numberFetched) == 0)
+                {
+                    IMoniker runningObjectMoniker = moniker[0];
+ 
+                    string name = null;
+ 
+                    try
+                    {
+                        if (runningObjectMoniker != null)
+                        {
+                            runningObjectMoniker.GetDisplayName(bindCtx, null, out name);
+                        }
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        // Do nothing, there is something in the ROT that we do not have access to.
+                    }
+ 
+                    // Parse the moniker to match against target spec. and extract process id.
+                    int processId;
+                    Match match = s_regex_dteMoniker.Match(name);
+                    if (!match.Success
+                        || match.Groups.Count != 2) {
+                        continue; }
+                    processId = int.Parse(match.Groups[1].Value);
+                    
+                    // Store the DTE.
+                    object runningObject = null;
+                    Marshal.ThrowExceptionForHR(rot.GetObject(runningObjectMoniker, out runningObject));
+                    dtes[processId] = (EnvDTE.DTE)runningObject;
+                }
+            }
+            finally
+            {
+                if (enumMonikers != null)
+                {
+                    Marshal.ReleaseComObject(enumMonikers);
+                }
+ 
+                if (rot != null)
+                {
+                    Marshal.ReleaseComObject(rot);
+                }
+ 
+                if (bindCtx != null)
+                {
+                    Marshal.ReleaseComObject(bindCtx);
+                }
+            }
+ 
+            return dtes;
+        }
+
+        /// <summary>
+        /// Attempts to load the specified process into a debugger using the specified debug engine
+        /// and the best debugger available.
+        /// If any instance of Visual Studio process is already associated with the current 
+        /// (calling) process, then that instance's debugger is targetd.
+        /// Otherwise, the any first instance of Visual Studio is targetd.
+        /// </summary>
+        /// <param name="subjectProcessId">Id of the process to be debugged.</param>
+        /// <param name="debugEngine">Name of the debugger script engine to use e.g. "script" or "native" or "managed".</param>
+/*
+        public static void DebugAttachToProcess(int subjectProcessId, string debugEngine)
+        {
+            // Register COM message filter on this thd to enforce a call retry policy
+            // should our COM calls into the DTE (in another apartment) be rejected.
+            using(var mf = new ResilientMessageFilterScope())
+            {
+                EnvDTE.DTE dte = GetAllDTEs().FirstOrDefault(x => ProcessExtensions.IsProcessAAncestorOfProcessB(x.Key, Process.GetCurrentProcess().Id)).Value;
+                if (dte == null) {
+                    dte = GetAllDTEs().FirstOrDefault().Value; }
+
+                IEnumerable<EnvDTE.Process> processes = dte.Debugger.LocalProcesses.OfType<EnvDTE.Process>();
+                EnvDTE.Process process = processes.SingleOrDefault(x => x.ProcessID == subjectProcessId);
+                // A.
+                if (process != null) {
+                    EnvDTE80.Process2 p2 = (EnvDTE80.Process2)process;
+                    p2.Attach2(debugEngine);
+                }
+                // B.
+                else {
+                    throw new InvalidOperationException("Unable to debug the process: Visual Studio debugger not found.");
+                        // TODO: spin up an instance of Visual Studio in this case?
+                }
+            }
+        }
+ */
+    }
+}

--- a/VS.Common/VS.Common.csproj
+++ b/VS.Common/VS.Common.csproj
@@ -87,6 +87,7 @@
     </Compile>
     <Compile Include="SolutionEventsListener.cs" />
     <Compile Include="SolutionEventsListenerEventArgs.cs" />
+    <Compile Include="VsDebuggerTestLauncher.cs" />
     <Compile Include="VsSolutionHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/VS.Common/VS.Common.csproj
+++ b/VS.Common/VS.Common.csproj
@@ -54,8 +54,29 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <COMReference Include="EnvDTE">
+      <Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
+      <VersionMajor>8</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </COMReference>
+    <COMReference Include="EnvDTE80">
+      <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
+      <VersionMajor>8</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="AdapterConstants.cs" />
     <Compile Include="ChutzpahTracingHelper.cs" />
+    <Compile Include="DteHelpers.cs" />
     <Compile Include="ILogger.cs" />
     <Compile Include="ISolutionEventsListener.cs" />
     <Compile Include="Logger.cs" />

--- a/VS.Common/VsDebuggerTestLauncher.cs
+++ b/VS.Common/VsDebuggerTestLauncher.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chutzpah;
+using Chutzpah.Models;
+using Chutzpah.Utility;
+
+namespace Chutzpah.VS.Common
+{
+    public class VsDebuggerTestLauncher : ITestLauncher
+    {
+        public void LaunchTest(TestContext testContext)
+        {
+            // Start IE.
+            ProcessStartInfo startInfo = new ProcessStartInfo()
+            {
+                UseShellExecute = true,
+                FileName = BrowserPathHelper.GetBrowserPath("ie"),
+                Arguments = string.Format("-noframemerging -suspended -debug {0}", FileProbe.GenerateFileUrl(testContext.TestHarnessPath))
+                    // -noframemerging
+                    //      This is what VS does when launching the script debugger.
+                    //      Unsure whether strictly necessary.
+                    // -suspended
+                    //      This is what VS does when launching the script debugger.
+                    //      Seems to cause IE to suspend all threads which is what we want.
+                    // -debug
+                    //      This is what VS does when launching the script debugger.
+                    //      Not sure exactly what it does.
+            };
+            Process ieMainProcess = Process.Start(startInfo);
+
+            // Get child 'tab' process spawned by IE.
+            // We need to wait a few ms for IE to open the process.
+            Process ieTabProcess = null;
+            for (int i = 0;; ++i) {
+                System.Threading.Thread.Sleep(10);
+                ieTabProcess = ProcessExtensions.FindFirstChildProcessOf(ieMainProcess.Id);
+                if (ieTabProcess != null) {
+                    break; }
+                if (i > 400) { // 400 * 10 = 4s timeout
+                    throw new InvalidOperationException("Timeout waiting for Internet Explorer child process to start."); }
+            }
+                           
+            // Debug the script in that tab process.
+            //DteHelpers.DebugAttachToProcess(ieTabProcess.Id, "script");
+
+            // Resume the threads in the IE process which where started off suspended.
+            ieTabProcess.Resume();
+        }
+
+        public void CleanupTest(TestContext testContext)
+        {
+            //TODO
+        }
+    }
+}

--- a/VS.Common/VsDebuggerTestLauncher.cs
+++ b/VS.Common/VsDebuggerTestLauncher.cs
@@ -45,7 +45,7 @@ namespace Chutzpah.VS.Common
             }
                            
             // Debug the script in that tab process.
-            //DteHelpers.DebugAttachToProcess(ieTabProcess.Id, "script");
+            DteHelpers.DebugAttachToProcess(ieTabProcess.Id, "script");
 
             // Resume the threads in the IE process which where started off suspended.
             ieTabProcess.Resume();

--- a/VS2012.TestAdapter/ChutzpahTestExecutor.cs
+++ b/VS2012.TestAdapter/ChutzpahTestExecutor.cs
@@ -38,8 +38,12 @@ namespace Chutzpah.VS2012.TestAdapter
 
             var testOptions = new TestOptions
                 {
-                    OpenInBrowser = settings.OpenInBrowser,
-                    MaxDegreeOfParallelism = settings.MaxDegreeOfParallelism,
+                    TestLaunchMode =
+                        runContext.IsBeingDebugged ? TestLaunchMode.Custom:
+                        settings.OpenInBrowser ? TestLaunchMode.FullBrowser:
+                        TestLaunchMode.HeadlessBrowser,
+                    CustomTestLauncher     = runContext.IsBeingDebugged ? new Chutzpah.VS.Common.VsDebuggerTestLauncher() : null,
+                    MaxDegreeOfParallelism = runContext.IsBeingDebugged ? 1 : settings.MaxDegreeOfParallelism,
                     ChutzpahSettingsFileEnvironments = new ChutzpahSettingsFileEnvironments(settings.ChutzpahSettingsFileEnvironments)
                 };
 

--- a/VisualStudioContextMenu/VisualStudioContextMenuPackage.cs
+++ b/VisualStudioContextMenu/VisualStudioContextMenuPackage.cs
@@ -367,7 +367,7 @@ namespace Chutzpah.VisualStudioContextMenu
                                                           {
                                                               Enabled = withCodeCoverage
                                                           },
-                                                          OpenInBrowser = openInBrowser,
+                                                          TestLaunchMode = openInBrowser ? TestLaunchMode.FullBrowser : TestLaunchMode.HeadlessBrowser,
                                                           ChutzpahSettingsFileEnvironments = settingsEnvironments
                                                       };
                                     var result = testRunner.RunTests(filePaths, options, runnerCallback);


### PR DESCRIPTION
Revised implementation as previously discussed (#381).

Now developed in VS2013. The problem with VS.Common was something to do with the way I was copying DLLs directly into the TestWindow\Extensions folder, I think.

Another odd thing was that if I DON'T bump the version number but keep the current number (4.0.3), installing the newly built VSIX package results in the previous, originally-installed package being re-installed. Furthermore, when building with the original version number, it seems to want to re-install the newly built package, right there during the build process. Finally, if the VS process doesn't have admin rights that attempt eventually bombs out after a couple of minutes.

It seems that the build.bat should be run as ```build package 4.0.4``` or whatever version number is required, that then overwriting any current version numbers in the in the AssemblyInfo.cs files.

Anyhow, when built as 4.0.4 and vsix installed into 2013, doing a right-click on a Test item in the test window with a BP set in the script, IE gets launched and the script breaks at the BP in the IDE.

Tested on Windows 7 x64 and IE 11.