### PR TITLE
adds /coverageIgnore option to exclude files from code coverage results

### DIFF
--- a/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
+++ b/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
@@ -168,7 +168,9 @@ namespace Chutzpah.Coverage
                     }
                 }
 
-                if (!(testContext.CoverageEngine != null && testContext.CoverageEngine.IsIgnored(newKey)) && fileSystem.FileExists(filePath))
+                if (IsFileEligibleForInstrumentation(newKey) &&
+                    !(testContext.CoverageEngine != null && testContext.CoverageEngine.IsIgnored(newKey)) &&
+                    fileSystem.FileExists(filePath))
                 {
                     string[] sourceLines = fileSystem.GetLines(filePath);
                     int?[] lineExecutionCounts = entry.Value;

--- a/Chutzpah/Coverage/ICoverageEngine.cs
+++ b/Chutzpah/Coverage/ICoverageEngine.cs
@@ -46,6 +46,19 @@ namespace Chutzpah.Coverage
         void AddExcludePatterns(IEnumerable<string> excludePatterns);
 
         /// <summary>
+        /// Add file name pattern that, if set, a file must NOT match to be included in results. Pattern matching
+        /// is done with the <c>PathMatchSpec</c> Windows function.
+        /// </summary>
+        void AddIgnorePatterns(IEnumerable<string> ignorePatterns);
+
+        /// <summary>
+        /// Returns true if the path should not be included in results, false otherwise.
+        /// </summary>
+        /// <param name="filePath">The path to test.</param>
+        /// <returns></returns>
+        bool IsIgnored(string filePath);
+
+        /// <summary>
         /// Reset patterns between runs, this is to prevent caching old configurations
         /// </summary>
         void ClearPatterns();

--- a/Chutzpah/CoverageOptions.cs
+++ b/Chutzpah/CoverageOptions.cs
@@ -12,6 +12,7 @@ namespace Chutzpah
         {
             IncludePatterns = new List<string>();
             ExcludePatterns = new List<string>();
+            IgnorePatterns = new List<string>();
         }
 
         /// <summary>
@@ -28,6 +29,11 @@ namespace Chutzpah
         /// If specified, pattern of files to exclude from the instrumentation phase.
         /// </summary>
         public ICollection<string> ExcludePatterns { get; set; }
+
+        /// <summary>
+        /// If specified, pattern of files to exclude from the results phase.
+        /// </summary>
+        public ICollection<string> IgnorePatterns { get; set; }
 
         public bool ShouldRunCoverage(CodeCoverageExecutionMode? coverageExecutionModeSetting)
         {

--- a/Chutzpah/Models/ChutzpahTestSettingsFile.cs
+++ b/Chutzpah/Models/ChutzpahTestSettingsFile.cs
@@ -56,6 +56,7 @@ namespace Chutzpah.Models
         {
             CodeCoverageIncludes = new List<string>();
             CodeCoverageExcludes = new List<string>();
+            CodeCoverageIgnores = new List<string>();
             References = new List<SettingsFileReference>();
             Tests = new List<SettingsFileTestPath>();
             Transforms = new List<TransformConfig>();
@@ -210,6 +211,11 @@ namespace Chutzpah.Models
         public ICollection<string> CodeCoverageExcludes { get; set; }
 
         /// <summary>
+        /// The collection code coverage file patterns to ignore in coverage. These are in glob format. If you specify none no files are excluded.
+        /// </summary>
+        public ICollection<string> CodeCoverageIgnores { get; set; }
+
+        /// <summary>
         /// The collection of test files. These can list individual tests or folders scanned recursively. This setting can work in two ways:
         /// 1. If you run tests normally by specifying folders/files then this settings will filter the sets of those files.
         /// 2. If you run tests by running a specific chutzpah.json file then this settings will select the test files you choose.
@@ -341,6 +347,7 @@ namespace Chutzpah.Models
             this.References = parent.References.Concat(this.References).ToList();
             this.CodeCoverageIncludes = parent.CodeCoverageIncludes.Concat(this.CodeCoverageIncludes).ToList();
             this.CodeCoverageExcludes = parent.CodeCoverageExcludes.Concat(this.CodeCoverageExcludes).ToList();
+            this.CodeCoverageIgnores = parent.CodeCoverageIgnores.Concat(this.CodeCoverageIgnores).ToList();
             this.Transforms = parent.Transforms.Concat(this.Transforms).ToList();
 
             if (this.Compile == null)

--- a/Chutzpah/TestContextBuilder.cs
+++ b/Chutzpah/TestContextBuilder.cs
@@ -417,6 +417,7 @@ namespace Chutzpah
             coverageEngine.ClearPatterns();
             coverageEngine.AddIncludePatterns(chutzpahTestSettings.CodeCoverageIncludes.Concat(options.CoverageOptions.IncludePatterns));
             coverageEngine.AddExcludePatterns(chutzpahTestSettings.CodeCoverageExcludes.Concat(options.CoverageOptions.ExcludePatterns));
+            coverageEngine.AddIgnorePatterns(chutzpahTestSettings.CodeCoverageIgnores.Concat(options.CoverageOptions.IgnorePatterns));
             return coverageEngine;
         }
 

--- a/ConsoleRunner/CommandLine.cs
+++ b/ConsoleRunner/CommandLine.cs
@@ -58,8 +58,10 @@ namespace Chutzpah
         public bool Coverage { get; protected set; }
 
         public string CoverageIncludePatterns { get; protected set; }
-        
+
         public string CoverageExcludePatterns { get; protected set; }
+
+        public string CoverageIgnorePatterns { get; protected set; }
 
         public string BrowserName { get; protected set; }
 
@@ -165,6 +167,10 @@ namespace Chutzpah
                 {
                     AddCoverageExcludeOption(option.Value);
                 }
+                else if (optionName == "/coverageignores")
+                {
+                    AddCoverageIgnoreOption(option.Value);
+                }
                 else if (optionName == "/showfailurereport")
                 {
                     GuardNoOptionValue(option);
@@ -205,6 +211,16 @@ namespace Chutzpah
                     "invalid or missing argument for /coverageExcludes.  Expecting a list of comma separated file name patterns");
             }
             CoverageExcludePatterns = value;
+        }
+
+        private void AddCoverageIgnoreOption(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException(
+                    "invalid or missing argument for /coverageIgnores.  Expecting a list of comma separated file name patterns");
+            }
+            CoverageIgnorePatterns = value;
         }
 
         private void AddParallelismOption(string value)

--- a/ConsoleRunner/Program.cs
+++ b/ConsoleRunner/Program.cs
@@ -148,7 +148,8 @@ namespace Chutzpah
                                               {
                                                   Enabled = commandLine.Coverage,
                                                   IncludePatterns = (commandLine.CoverageIncludePatterns ?? "").Split(new[]{','},StringSplitOptions.RemoveEmptyEntries),
-                                                  ExcludePatterns = (commandLine.CoverageExcludePatterns ?? "").Split(new[]{','},StringSplitOptions.RemoveEmptyEntries)
+                                                  ExcludePatterns = (commandLine.CoverageExcludePatterns ?? "").Split(new[]{','},StringSplitOptions.RemoveEmptyEntries),
+                                                  IgnorePatterns = (commandLine.CoverageIgnorePatterns ?? "").Split(new[]{','},StringSplitOptions.RemoveEmptyEntries)
                                               }
                     };
 

--- a/Facts.Integration/Coverage.cs
+++ b/Facts.Integration/Coverage.cs
@@ -440,6 +440,21 @@ namespace Chutzpah.Facts.Integration
 
         [Theory]
         [PropertyData("AmdTestScriptWithForcedRequire")]
+        public void Will_ignore_only_given_file_patterns(string scriptPath)
+        {
+            var testRunner = TestRunner.Create();
+
+            var result = testRunner.RunTests(scriptPath, WithCoverage(co => { co.IncludePatterns = new[] { "*\\ui\\*", "*core.js" }; co.IgnorePatterns = new[] { "tests\\*" }; }), new ExceptionThrowingRunnerCallback());
+
+            ExpectKeysMatching(result.TestFileSummaries.Single().CoverageObject,
+                               new[]
+                                   {
+                                      "\\base\\core.js", "ui\\screen.js"
+                                   });
+        }
+
+        [Theory]
+        [PropertyData("AmdTestScriptWithForcedRequire")]
         public void Will_resolve_requirejs_required_files_correctly(string scriptPath)
         {
             var testRunner = TestRunner.Create();

--- a/Facts/ConsoleRunner/CommandLineFacts.cs
+++ b/Facts/ConsoleRunner/CommandLineFacts.cs
@@ -591,6 +591,16 @@ namespace Chutzpah.Facts.ConsoleRunner
             }
 
             [Fact]
+            public void CoverageExclude_Option_Not_Passed_CoverageIgnorePattern_Null()
+            {
+                var arguments = new[] { "test.html" };
+
+                var commandLine = TestableCommandLine.Create(arguments);
+
+                Assert.Null(commandLine.CoverageIgnorePatterns);
+            }
+
+            [Fact]
             public void CoverageInclude_Option_With_Value_CoverageIncludePattern_Set()
             {
                 var arguments = new[] { "test.html", "/coverageIncludes", "*.js" };
@@ -608,6 +618,16 @@ namespace Chutzpah.Facts.ConsoleRunner
                 var commandLine = TestableCommandLine.Create(arguments);
 
                 Assert.Equal("*.coffee", commandLine.CoverageExcludePatterns);
+            }
+
+            [Fact]
+            public void CoverageExclude_Option_With_Value_CoverageIgnorePattern_Set()
+            {
+                var arguments = new[] { "test.html", "/coverageIgnores", "*.ts" };
+
+                var commandLine = TestableCommandLine.Create(arguments);
+
+                Assert.Equal("*.ts", commandLine.CoverageIgnorePatterns);
             }
 
             [Fact]

--- a/Facts/Library/Models/ChutzpahTestSettingsServiceFacts.cs
+++ b/Facts/Library/Models/ChutzpahTestSettingsServiceFacts.cs
@@ -241,7 +241,8 @@ namespace Chutzpah.Facts.Library.Models
                 References = new List<SettingsFileReference> { new SettingsFileReference { Path = "parentReferencePath" } },
                 Transforms = new List<TransformConfig>{ new TransformConfig{ Path = "parentTransformPath"}},
                 CodeCoverageExcludes = new List<string>{"parentCodeCoverageExcludePath"},
-                CodeCoverageIncludes = new List<string>{"parentCodeCoverageIncludePath"},
+                CodeCoverageIncludes = new List<string> { "parentCodeCoverageIncludePath" },
+                CodeCoverageIgnores = new List<string> { "parentCodeCoverageIgnorePath" },
                 Compile = new BatchCompileConfiguration{ Mode = BatchCompileMode.External},
                 
                 AMDBasePath = "parentAmdBasePath",
@@ -277,6 +278,7 @@ namespace Chutzpah.Facts.Library.Models
             Assert.Equal(1, childSettings.Transforms.Count);
             Assert.Equal(1, childSettings.CodeCoverageIncludes.Count);
             Assert.Equal(1, childSettings.CodeCoverageExcludes.Count);
+            Assert.Equal(1, childSettings.CodeCoverageIgnores.Count);
 
             Assert.Equal(parentSettings.Compile, childSettings.Compile);
             Assert.Equal(@"C:\settingsDir", childSettings.SettingsFileDirectory);
@@ -305,7 +307,8 @@ namespace Chutzpah.Facts.Library.Models
                 References = new List<SettingsFileReference> { new SettingsFileReference { Path = "parentReferencePath" } },
                 Transforms = new List<TransformConfig> { new TransformConfig { Path = "parentTransformPath" } },
                 CodeCoverageExcludes = new List<string> { "parentCodeCoverageExcludePath" },
-                CodeCoverageIncludes = new List<string> { "parentCodeCoverageIncludePath" }
+                CodeCoverageIncludes = new List<string> { "parentCodeCoverageIncludePath" },
+                CodeCoverageIgnores = new List<string> { "parentCodeCoverageIgnorePath" }
             };
 
             var childSettings = new ChutzpahTestSettingsFile
@@ -315,7 +318,8 @@ namespace Chutzpah.Facts.Library.Models
                 References = new List<SettingsFileReference> { new SettingsFileReference { Path = "childReferencePath" } },
                 Transforms = new List<TransformConfig> { new TransformConfig { Path = "childTransformPath" } },
                 CodeCoverageExcludes = new List<string> { "childCodeCoverageExcludePath" },
-                CodeCoverageIncludes = new List<string> { "childCodeCoverageIncludePath" }
+                CodeCoverageIncludes = new List<string> { "childCodeCoverageIncludePath" },
+                CodeCoverageIgnores = new List<string> { "childCodeCoverageIgnorePath" }
             };
 
             service.Mock<IFileProbe>().Setup(x => x.FindTestSettingsFile(@"C:\settingsDir")).Returns(@"C:\settingsDir\settingsFile.json");
@@ -348,6 +352,9 @@ namespace Chutzpah.Facts.Library.Models
             Assert.Equal(2, childSettings.CodeCoverageExcludes.Count);
             Assert.Equal("parentCodeCoverageExcludePath", childSettings.CodeCoverageExcludes.ElementAt(0));
             Assert.Equal("childCodeCoverageExcludePath", childSettings.CodeCoverageExcludes.ElementAt(1));
+            Assert.Equal(2, childSettings.CodeCoverageIgnores.Count);
+            Assert.Equal("parentCodeCoverageIgnorePath", childSettings.CodeCoverageIgnores.ElementAt(0));
+            Assert.Equal("childCodeCoverageIgnorePath", childSettings.CodeCoverageIgnores.ElementAt(1));
         }
 
         [Fact]


### PR DESCRIPTION
My implementation of a solution for #404. Adds a /coverageIgnore command-line option (and corresponding "CodeCoverageIgnores" option in chutzpah.json), much like the existing /coverageInclude and /coverageExclude options. Ignored files are not added to the CoverageData object, thus don't appear in the coverage output.