### PR TITLE
Use seconds for timings in JUnit XML

### DIFF
--- a/Chutzpah/Transformers/JUnitXmlTransformer.cs
+++ b/Chutzpah/Transformers/JUnitXmlTransformer.cs
@@ -36,14 +36,14 @@ namespace Chutzpah.Transformers
             {
                 builder.AppendLine(
                     string.Format(@"  <testsuite name=""{0}"" tests=""{1}"" failures=""{2}"" time=""{3}"">",
-                                  Encode(file.Path), file.Tests.Count, file.Tests.Count(x => !x.ResultsAllPassed), file.TimeTaken));
+                                  Encode(file.Path), file.Tests.Count, file.Tests.Count(x => !x.ResultsAllPassed), ConvertMillisecondsToSeconds(file.TimeTaken)));
                 ;
                 foreach (TestCase test in file.Tests)
                 {
                     if (test.ResultsAllPassed)
                     {
                         builder.AppendLine(string.Format(@"    <testcase name=""{0}"" time=""{1}"" />",
-                                           Encode(test.GetDisplayName()), test.TimeTaken));
+                                           Encode(test.GetDisplayName()), ConvertMillisecondsToSeconds(test.TimeTaken)));
                     }
                     else
                     {
@@ -52,7 +52,7 @@ namespace Chutzpah.Transformers
                         {
                             string failureMessage = failureCase.GetFailureMessage();
                             builder.AppendLine(string.Format(@"    <testcase name=""{0}"" time=""{1}"">",
-                                                             Encode(test.GetDisplayName()), test.TimeTaken));
+                                                             Encode(test.GetDisplayName()), ConvertMillisecondsToSeconds(test.TimeTaken)));
                             builder.AppendLine(string.Format(@"      <failure message=""{0}""></failure>",
                                                              Encode(failureMessage)));
                             builder.AppendLine(string.Format(@"    </testcase>"));

--- a/Chutzpah/Transformers/SummaryTransformer.cs
+++ b/Chutzpah/Transformers/SummaryTransformer.cs
@@ -40,7 +40,12 @@ namespace Chutzpah.Transformers
             }
 
             var result = Transform(testFileSummary);
-            fileSystem.WriteAllText(outFile, result,Encoding);
+            fileSystem.WriteAllText(outFile, result, Encoding);
         }
+
+		protected decimal ConvertMillisecondsToSeconds(long millis)
+		{
+			return millis / 1000m;
+		}
     }
 }

--- a/Facts/Library/Transformers/JUnitXmlTransformerFacts.cs
+++ b/Facts/Library/Transformers/JUnitXmlTransformerFacts.cs
@@ -71,15 +71,15 @@ namespace Chutzpah.Facts.Library.Transformers
             var expected =
                 @"<?xml version=""1.0"" encoding=""UTF-8"" ?>
 <testsuites>
-  <testsuite name=""path1"" tests=""2"" failures=""1"" time=""1500"">
-    <testcase name=""module1:test1"" time=""1000"">
+  <testsuite name=""path1"" tests=""2"" failures=""1"" time=""1.5"">
+    <testcase name=""module1:test1"" time=""1"">
       <failure message=""some failure""></failure>
     </testcase>
-    <testcase name=""module1:test2"" time=""500"" />
+    <testcase name=""module1:test2"" time=""0.5"" />
   </testsuite>
-  <testsuite name=""path&gt;2"" tests=""2"" failures=""1"" time=""2000"">
-    <testcase name=""test3"" time=""1000"" />
-    <testcase name=""test&lt;4"" time=""1000"">
+  <testsuite name=""path&gt;2"" tests=""2"" failures=""1"" time=""2"">
+    <testcase name=""test3"" time=""1"" />
+    <testcase name=""test&lt;4"" time=""1"">
       <failure message=""bad&lt;failure""></failure>
     </testcase>
   </testsuite>


### PR DESCRIPTION
Fixes #409. The timings in the JUnit XML format are required to be in
seconds, not milliseconds.