### PR TITLE
Remove BOM from transformed result output

### DIFF
--- a/Chutzpah/Transformers/SummaryTransformer.cs
+++ b/Chutzpah/Transformers/SummaryTransformer.cs
@@ -11,11 +11,15 @@ namespace Chutzpah.Transformers
     /// </summary>
     public abstract class SummaryTransformer
     {
+        // Encoding for UTF-8 that will not output a byte-order mark
+        private static readonly Encoding UTF8NoIdentifier = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         /// <summary>
         /// The encoding used to write the string response from Transform.
         /// </summary>
-        public virtual Encoding Encoding {
-            get { return Encoding.UTF8; }
+        public virtual Encoding Encoding
+        {
+            get { return UTF8NoIdentifier; }
         }
         public abstract string Name { get; }
         public abstract string Description { get; }

--- a/Facts/Facts.csproj
+++ b/Facts/Facts.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Library\TestHarnessBuilderFacts.cs" />
     <Compile Include="Library\TestHarnessFacts.cs" />
     <Compile Include="Library\TestingModeExtensionsFacts.cs" />
+    <Compile Include="Library\Transformers\SummaryTransformerFacts.cs" />
     <Compile Include="Library\Transformers\NUnit2XmlTransformerFacts.cs" />
     <Compile Include="Library\Transformers\JUnitXmlTransformerFacts.cs" />
     <Compile Include="Library\Transformers\LcovTransformerFacts.cs" />

--- a/Facts/Library/Transformers/SummaryTransformerFacts.cs
+++ b/Facts/Library/Transformers/SummaryTransformerFacts.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using Chutzpah.Models;
+using Chutzpah.Transformers;
+using Xunit;
+using Chutzpah.Wrappers;
+using Moq;
+using System.Text;
+
+namespace Chutzpah.Facts.Library.Transformers
+{
+    public class SummaryTransformerFacts
+    {
+        [Fact]
+        public void Will_write_utf8_without_byte_order_mark()
+        {
+            Encoding summaryEncoding = null;
+
+            var fsw = new Mock<IFileSystemWrapper>();
+            fsw.Setup(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Encoding>()))
+                .Callback<string, string, Encoding>((path, text, enc) => { summaryEncoding = enc; })
+                .Verifiable();
+
+            var sut = new TestSummaryTransformer(fsw.Object);
+
+            sut.Transform(new TestCaseSummary(), "outputfile");
+
+            fsw.Verify(); // Write called
+            Assert.NotNull(summaryEncoding); // encoding captured
+            Assert.Empty(summaryEncoding.GetPreamble()); // encoding has no BOM preamble
+            Assert.Empty(summaryEncoding.GetBytes(""));  // encoding does not write leading bytes to output
+        }
+
+        private class TestSummaryTransformer : SummaryTransformer
+        {
+            public TestSummaryTransformer(IFileSystemWrapper wrapper) : base(wrapper)
+            {
+            }
+
+            public override string Name
+            {
+                get { return "Test"; }
+            }
+
+            public override string Description
+            {
+                get { return "Test"; }
+            }
+
+            public override string Transform(TestCaseSummary testFileSummary)
+            {
+                return "";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #411. The BOM causes errors when read by many Java libraries, including those used by Jenkins. It's optional, so it can simply be removed, making (in particular) Jenkins integration easier.