### PR TITLE
Fix bugs: AMD modules and different "non canonical" references and CoverageData.Merge do not update Percentage

### DIFF
--- a/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
+++ b/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
@@ -180,12 +180,22 @@ namespace Chutzpah.Coverage
                         lineExecutionCounts = this.lineCoverageMapper.GetOriginalFileLineExecutionCounts(entry.Value, sourceLines.Length, referencedFile);
                     }
 
-                    coverageData.Add(newKey, new CoverageFileData
+                    var coverageFileData = new CoverageFileData
+                                               {
+                                                   LineExecutionCounts = lineExecutionCounts,
+                                                   FilePath = newKey,
+                                                   SourceLines = sourceLines
+                                               };
+                    
+                    // If some AMD modules has different "non canonical" references (like "../../module" and "./../../module"). Coverage trying to add files many times
+                    if (coverageData.ContainsKey(newKey))
                     {
-                        LineExecutionCounts = lineExecutionCounts,
-                        FilePath = newKey,
-                        SourceLines = sourceLines
-                    });
+                        coverageData[newKey].Merge(coverageFileData);
+                    }
+                    else
+                    {
+                        coverageData.Add(newKey, coverageFileData);
+                    }
                 }
             }
             return coverageData;

--- a/Chutzpah/Models/CoverageData.cs
+++ b/Chutzpah/Models/CoverageData.cs
@@ -219,6 +219,9 @@ namespace Chutzpah.Models
                     }
                 }
             }
+
+            // After update LineExecutionCounts we need recalculate CoveragePercentage
+            this.coveragePercentage = null;
         }
     }
 }


### PR DESCRIPTION
Fix bugs: 
1) AMD modules and different "non canonical" references
2) CoverageData.Merge do not update Percentage