### PR TITLE
Fix bugs: AMD modules and different "non canonical" references and CoverageData.Merge do not update Percentage

### DIFF
--- a/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
+++ b/Chutzpah/Coverage/BlanketJsCoverageEngine.cs
@@ -180,12 +180,22 @@ namespace Chutzpah.Coverage
                         lineExecutionCounts = this.lineCoverageMapper.GetOriginalFileLineExecutionCounts(entry.Value, sourceLines.Length, referencedFile);
                     }
 
-                    coverageData.Add(newKey, new CoverageFileData
+                    var coverageFileData = new CoverageFileData
+                                               {
+                                                   LineExecutionCounts = lineExecutionCounts,
+                                                   FilePath = newKey,
+                                                   SourceLines = sourceLines
+                                               };
+                    
+                    // If some AMD modules has different "non canonical" references (like "../../module" and "./../../module"). Coverage trying to add files many times
+                    if (coverageData.ContainsKey(newKey))
                     {
-                        LineExecutionCounts = lineExecutionCounts,
-                        FilePath = newKey,
-                        SourceLines = sourceLines
-                    });
+                        coverageData[newKey].Merge(coverageFileData);
+                    }
+                    else
+                    {
+                        coverageData.Add(newKey, coverageFileData);
+                    }
                 }
             }
             return coverageData;

--- a/Chutzpah/Models/CoverageData.cs
+++ b/Chutzpah/Models/CoverageData.cs
@@ -219,6 +219,9 @@ namespace Chutzpah.Models
                     }
                 }
             }
+
+            // After update LineExecutionCounts we need recalculate CoveragePercentage
+            this.coveragePercentage = null;
         }
     }
 }

--- a/Chutzpah/Models/CoverageData.cs
+++ b/Chutzpah/Models/CoverageData.cs
@@ -222,6 +222,7 @@ namespace Chutzpah.Models
 
             // After update LineExecutionCounts we need recalculate CoveragePercentage
             this.coveragePercentage = null;
+            this.coveredCount = null;
         }
     }
 }

--- a/Facts.Integration/CoverageFileDataFacts.cs
+++ b/Facts.Integration/CoverageFileDataFacts.cs
@@ -1,0 +1,68 @@
+﻿using System.Linq;
+
+using Chutzpah.Models;
+
+using Xunit;
+
+namespace Chutzpah.Facts.Integration
+{
+    public class CoverageFileDataFacts
+    {
+        private CoverageFileData data1;
+
+        private CoverageFileData data2;
+
+        public CoverageFileDataFacts()
+        {
+            this.data1 = new CoverageFileData
+            {
+                FilePath = "test1",
+                LineExecutionCounts = new int?[] { null, 1, 0, 1 },
+                SourceLines = new[] { "" }
+            };
+
+            this.data2 = new CoverageFileData
+            {
+                FilePath = "test1",
+                LineExecutionCounts = new int?[] { null, 0, 1, 0 },
+                SourceLines = new[] { "" }
+            };
+        }
+
+        [Fact]
+        public void Will_CoveragePercentage_calculated_right_for_Data1()
+        {
+            // Arrange
+            // Act
+            var percentage = this.data1.CoveragePercentage;
+
+            // Assert
+            Assert.Equal(0.67, percentage, 2);
+        }
+
+        [Fact]
+        public void Will_CoveragePercentage_calculated_right_for_Data2()
+        {
+            // Arrange
+            // Act
+            var percentage = this.data2.CoveragePercentage;
+
+            // Assert
+            Assert.Equal(0.33, percentage, 2);
+        }
+
+        [Fact]
+        public void If_call_CoveragePercentage_before_merge_Data1_and_Data2_and_after_merge_CoveragePercentage_changing()
+        {
+            // Arrange
+            var fakePercentage = this.data1.CoveragePercentage;
+            this.data1.Merge(this.data2);
+
+            // Act
+            var percentage = this.data1.CoveragePercentage;
+
+            // Assert
+            Assert.Equal(1, percentage, 2);
+        }
+    }
+}

--- a/Facts.Integration/Facts.Integration.csproj
+++ b/Facts.Integration/Facts.Integration.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="Coverage.cs" />
     <Compile Include="CoverageBase.cs" />
+    <Compile Include="CoverageFileDataFacts.cs" />
     <Compile Include="Discovery.cs" />
     <Compile Include="ExceptionThrowingRunnerCallback.cs" />
     <Compile Include="Execution.cs" />


### PR DESCRIPTION
Fix bugs: 
1) AMD modules and different "non canonical" references
2) CoverageData.Merge do not update Percentage

And add tests