### PR TITLE
Update test.js

### DIFF
--- a/Samples/Angular/TemplateDirective/test.js
+++ b/Samples/Angular/TemplateDirective/test.js
@@ -17,8 +17,8 @@ describe("Unit Tests for the Template Direktive ", function() {
         beforeEach(function () {
             inject(function ($templateCache) {
                 //Find The Template in the current Unit Test HTML
-                var templateFromComment = document.getElementById("template_comment").outerHTML;
-                var templateFromJson = document.getElementById("template_json").outerHTML;
+                var templateFromComment = document.getElementById("template_comment").innerHTML;
+                var templateFromJson = document.getElementById("template_json").innerHTML;
                 //Set TemplateURL here and add the Template
                 $templateCache.put("directiveTemplate_comment.html", templateFromComment);
                 $templateCache.put("directiveTemplate_json.html", templateFromJson);


### PR DESCRIPTION
the outerHtml was needed in my code examples without your implementation of an script tag. But with the script tag and the ID for the script tag, we only need to get the inner HTML because with: 
    "document.getElementById("template_comment")" 
we get the Script Tag you create and for our template we only need the template code exclude the script tags.