### PR TITLE
Added Emma XML coverage transformer + Unit tests

### DIFF
--- a/Chutzpah/Chutzpah.csproj
+++ b/Chutzpah/Chutzpah.csproj
@@ -157,6 +157,7 @@
     <Compile Include="TestCaseStreamReader.cs" />
     <Compile Include="EmbeddedManifestResourceReader.cs" />
     <Compile Include="ChutzpahTracer.cs" />
+    <Compile Include="Transformers\EmmaXmlTransformer.cs" />
     <Compile Include="Transformers\CoverageJsonTransformer.cs" />
     <Compile Include="Transformers\ISummaryTransformerProvider.cs" />
     <Compile Include="Transformers\ITransformProcessor.cs" />

--- a/Chutzpah/Transformers/EmmaXmlTransformer.cs
+++ b/Chutzpah/Transformers/EmmaXmlTransformer.cs
@@ -1,15 +1,13 @@
 ﻿using Chutzpah.Models;
 using Chutzpah.Wrappers;
 using System;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Web.UI;
 
 namespace Chutzpah.Transformers
 {
     /// <summary>
-    /// Outputs an XML file with a schema similar to the one found at http://emma.sourceforge.net/coverage_sample_c/coverage.xml
+    /// Outputs an XML file with code coverage results.
+    /// Schema used: http://emma.sourceforge.net/coverage_sample_c/coverage.xml
     /// </summary>
     public class EmmaXmlTransformer : SummaryTransformer
     {
@@ -26,7 +24,7 @@ namespace Chutzpah.Transformers
 
         public override string Description
         {
-            get { return "output results to Emma-style XML file"; }
+            get { return "output coverage results to an Emma-style XML file"; }
         }
 
         public EmmaXmlTransformer(IFileSystemWrapper fileSystem)
@@ -60,8 +58,8 @@ namespace Chutzpah.Transformers
         private void AppendOverallStats(StringBuilder builder, CoverageData coverage)
         {
             builder.AppendLine(@" <stats>");
-            builder.AppendLine(String.Format(@"  <srcfiles value=""{0}"" />", this.TotalSourceFiles));
-            builder.AppendLine(String.Format(@"  <srclines value=""{0}"" />", this.TotalSourceLines));
+            builder.AppendLine(string.Format(@"  <srcfiles value=""{0}"" />", this.TotalSourceFiles));
+            builder.AppendLine(string.Format(@"  <srclines value=""{0}"" />", this.TotalSourceLines));
             builder.AppendLine(@" </stats>");
         }
 
@@ -85,7 +83,7 @@ namespace Chutzpah.Transformers
         {
             var totalStatements = 0;
             var statementsCovered = 0;
-            builder.AppendLine(String.Format(@"   <srcfile name=""{0}"">", fileName));
+            builder.AppendLine(string.Format(@"   <srcfile name=""{0}"">", fileName));
 
             for (var i = 1; i < fileData.LineExecutionCounts.Length; i++)
             {
@@ -110,7 +108,7 @@ namespace Chutzpah.Transformers
             {
                 this.TotalSourceFiles += 1;
                 var fileData = pair.Value;
-                var totalSmts = 0;
+                var totalStatements = 0;
                 if (fileData.LineExecutionCounts == null)
                 {
                     continue;
@@ -121,7 +119,7 @@ namespace Chutzpah.Transformers
                     var lineExecution = fileData.LineExecutionCounts[i];
                     if (lineExecution.HasValue)
                     {
-                        totalSmts++;
+                        totalStatements++;
 
                         if (lineExecution > 0)
                         {
@@ -129,13 +127,13 @@ namespace Chutzpah.Transformers
                         }
                     }
                 }
-                this.TotalSourceLines += totalSmts;
+                this.TotalSourceLines += totalStatements;
             }
         }
 
         private void AppendLineCoverageForSourceFile(StringBuilder builder, int statementsCovered, int totalStatements)
         {
-            var lineCoverage = String.Format(
+            var lineCoverage = string.Format(
                 @"    <coverage type=""line, %"" value=""{0}% ({1}/{2})"" />",
                 FormatPercentage(statementsCovered, totalStatements),
                 statementsCovered,
@@ -145,7 +143,7 @@ namespace Chutzpah.Transformers
 
         private void AppendOverallCoverage(StringBuilder builder)
         {
-            var overall = String.Format(
+            var overall = string.Format(
                 @"   <coverage type=""line, %"" value=""{0}% ({1}/{2})"" />",
                 FormatPercentage(this.TotalSourceLinesCovered, this.TotalSourceLines),
                 this.TotalSourceLinesCovered,

--- a/Chutzpah/Transformers/EmmaXmlTransformer.cs
+++ b/Chutzpah/Transformers/EmmaXmlTransformer.cs
@@ -1,0 +1,162 @@
+﻿using Chutzpah.Models;
+using Chutzpah.Wrappers;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Web.UI;
+
+namespace Chutzpah.Transformers
+{
+    /// <summary>
+    /// Outputs an XML file with a schema similar to the one found at http://emma.sourceforge.net/coverage_sample_c/coverage.xml
+    /// </summary>
+    public class EmmaXmlTransformer : SummaryTransformer
+    {
+        private int TotalSourceFiles { get; set; }
+
+        private int TotalSourceLines { get; set; }
+
+        private int TotalSourceLinesCovered { get; set; }
+
+        public override string Name
+        {
+            get { return "emma"; }
+        }
+
+        public override string Description
+        {
+            get { return "output results to Emma-style XML file"; }
+        }
+
+        public EmmaXmlTransformer(IFileSystemWrapper fileSystem)
+            : base(fileSystem)
+        {
+
+        }
+
+        public override string Transform(TestCaseSummary testFileSummary)
+        {
+            if (testFileSummary == null)
+            {
+                throw new ArgumentNullException("testFileSummary");
+            }
+
+            GetOverallStats(testFileSummary.CoverageObject);
+            var builder = new StringBuilder();
+            builder.AppendLine(@"<?xml version=""1.0"" encoding=""UTF-8"" ?>");
+            builder.AppendLine(@"<report>");
+            AppendOverallStats(builder, testFileSummary.CoverageObject);
+            builder.AppendLine(@" <data>");
+            builder.AppendLine(@"  <all name=""all classes"">");
+            AppendOverallCoverage(builder);
+            AppendCoverageBySourceFile(builder, testFileSummary.CoverageObject);
+            builder.AppendLine(@"  </all>");
+            builder.AppendLine(@" </data>");
+            builder.AppendLine(@"</report>");
+            return builder.ToString();
+        }
+
+        private void AppendOverallStats(StringBuilder builder, CoverageData coverage)
+        {
+            builder.AppendLine(@" <stats>");
+            builder.AppendLine(String.Format(@"  <srcfiles value=""{0}"" />", this.TotalSourceFiles));
+            builder.AppendLine(String.Format(@"  <srclines value=""{0}"" />", this.TotalSourceLines));
+            builder.AppendLine(@" </stats>");
+        }
+
+        private void AppendCoverageBySourceFile(StringBuilder builder, CoverageData coverage)
+        {
+            foreach (var pair in coverage)
+            {
+                var fileName = pair.Key;
+                var fileData = pair.Value;
+
+                if (fileData.LineExecutionCounts == null)
+                {
+                    continue;
+                }
+
+                AppendCoverageForOneSourceFile(builder, fileName, fileData);
+            }
+        }
+
+        private void AppendCoverageForOneSourceFile(StringBuilder builder, string fileName, CoverageFileData fileData)
+        {
+            var totalStatements = 0;
+            var statementsCovered = 0;
+            builder.AppendLine(String.Format(@"   <srcfile name=""{0}"">", fileName));
+
+            for (var i = 1; i < fileData.LineExecutionCounts.Length; i++)
+            {
+                var lineExecution = fileData.LineExecutionCounts[i];
+                if (lineExecution.HasValue)
+                {
+                    totalStatements++;
+                    if (lineExecution > 0)
+                    {
+                        statementsCovered += 1;
+                    }
+                }
+            }
+
+            AppendLineCoverageForSourceFile(builder, statementsCovered, totalStatements);
+            builder.AppendLine(@"   </srcfile>");
+        }
+
+        private void GetOverallStats(CoverageData coverage)
+        {
+            foreach (var pair in coverage)
+            {
+                this.TotalSourceFiles += 1;
+                var fileData = pair.Value;
+                var totalSmts = 0;
+                if (fileData.LineExecutionCounts == null)
+                {
+                    continue;
+                }
+
+                for (var i = 1; i < fileData.LineExecutionCounts.Length; i++)
+                {
+                    var lineExecution = fileData.LineExecutionCounts[i];
+                    if (lineExecution.HasValue)
+                    {
+                        totalSmts++;
+
+                        if (lineExecution > 0)
+                        {
+                            this.TotalSourceLinesCovered += 1;
+                        }
+                    }
+                }
+                this.TotalSourceLines += totalSmts;
+            }
+        }
+
+        private void AppendLineCoverageForSourceFile(StringBuilder builder, int statementsCovered, int totalStatements)
+        {
+            var lineCoverage = String.Format(
+                @"    <coverage type=""line, %"" value=""{0}% ({1}/{2})"" />",
+                FormatPercentage(statementsCovered, totalStatements),
+                statementsCovered,
+                totalStatements);
+            builder.AppendLine(lineCoverage);
+        }
+
+        private void AppendOverallCoverage(StringBuilder builder)
+        {
+            var overall = String.Format(
+                @"   <coverage type=""line, %"" value=""{0}% ({1}/{2})"" />",
+                FormatPercentage(this.TotalSourceLinesCovered, this.TotalSourceLines),
+                this.TotalSourceLinesCovered,
+                this.TotalSourceLines);
+            builder.AppendLine(overall);
+        }
+
+        private static double FormatPercentage(int number, int total)
+        {
+            // with no fractional digits
+            return Math.Round((number / (double)total) * 100, 0);
+        }
+    }
+}

--- a/Chutzpah/Transformers/SummaryTransformerProvider.cs
+++ b/Chutzpah/Transformers/SummaryTransformerProvider.cs
@@ -10,14 +10,15 @@ namespace Chutzpah.Transformers
     {
         public IEnumerable<SummaryTransformer> GetTransformers(IFileSystemWrapper fileSystem)
         {
-            return new SummaryTransformer[] 
+            return new SummaryTransformer[]
             {
                 new JUnitXmlTransformer(fileSystem),
                 new LcovTransformer(fileSystem),
                 new TrxXmlTransformer(fileSystem),
                 new NUnit2XmlTransformer(fileSystem),
                 new CoverageHtmlTransformer(fileSystem),
-                new CoverageJsonTransformer(fileSystem)
+                new CoverageJsonTransformer(fileSystem),
+                new EmmaXmlTransformer(fileSystem),
             };
         }
     }

--- a/Facts/Facts.csproj
+++ b/Facts/Facts.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Library\TestHarnessBuilderFacts.cs" />
     <Compile Include="Library\TestHarnessFacts.cs" />
     <Compile Include="Library\TestingModeExtensionsFacts.cs" />
+    <Compile Include="Library\Transformers\EmmaXmlTransformerFacts.cs" />
     <Compile Include="Library\Transformers\SummaryTransformerFacts.cs" />
     <Compile Include="Library\Transformers\NUnit2XmlTransformerFacts.cs" />
     <Compile Include="Library\Transformers\JUnitXmlTransformerFacts.cs" />

--- a/Facts/Library/Transformers/EmmaXmlTransformerFacts.cs
+++ b/Facts/Library/Transformers/EmmaXmlTransformerFacts.cs
@@ -1,0 +1,99 @@
+﻿using Chutzpah.Models;
+using Chutzpah.Wrappers;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Chutzpah.Transformers;
+using Xunit;
+
+namespace Chutzpah.Facts.Library.Transformers
+{
+    public class EmmaXmlTransformerFacts
+    {
+        private static TestCaseSummary GetTestCaseSummary()
+        {
+            var testCaseSummary = new TestCaseSummary();
+            testCaseSummary.CoverageObject = new CoverageData();
+
+            testCaseSummary.CoverageObject["/no/coverage"] = new CoverageFileData
+            {
+                FilePath = "/no/coverage",
+                LineExecutionCounts = null
+            };
+
+            testCaseSummary.CoverageObject["/three/lines/two/covered"] = new CoverageFileData
+            {
+                FilePath = "/three/lines/two/covered",
+                LineExecutionCounts = new int?[] { null, 2, null, 5, 0 }
+            };
+
+            testCaseSummary.CoverageObject["/four/lines/four/covered"] = new CoverageFileData
+            {
+                FilePath = "/four/lines/four/covered",
+                LineExecutionCounts = new int?[] { null, 2, 3, 4, 5 }
+            };
+
+            return testCaseSummary;
+        }
+
+        private IFileSystemWrapper GetFileSystemWrapper()
+        {
+            return new Mock<IFileSystemWrapper>().Object;
+        }
+
+        [Fact]
+        public void Should_Have_Correct_Name()
+        {
+            Assert.Equal("emma", new EmmaXmlTransformer(GetFileSystemWrapper()).Name);
+        }
+
+        [Fact]
+        public void Should_Have_Non_Empty_Description()
+        {
+            Assert.False(string.IsNullOrWhiteSpace(new EmmaXmlTransformer(GetFileSystemWrapper()).Description));
+        }
+
+        [Fact]
+        public void Should_Throw_If_TestCaseSummary_Is_Null()
+        {
+            var transformer = new EmmaXmlTransformer(GetFileSystemWrapper());
+
+            Exception ex = Record.Exception(() => transformer.Transform(null));
+
+            Assert.IsType<ArgumentNullException>(ex);
+        }
+
+        [Fact]
+        public void Should_Generate_Xml()
+        {
+            var transformer = new EmmaXmlTransformer(GetFileSystemWrapper());
+            var summary = GetTestCaseSummary();
+            var expected =
+@"<?xml version=""1.0"" encoding=""UTF-8"" ?>
+<report>
+ <stats>
+  <srcfiles value=""3"" />
+  <srclines value=""7"" />
+ </stats>
+ <data>
+  <all name=""all classes"">
+   <coverage type=""line, %"" value=""86% (6/7)"" />
+   <srcfile name=""/three/lines/two/covered"">
+    <coverage type=""line, %"" value=""67% (2/3)"" />
+   </srcfile>
+   <srcfile name=""/four/lines/four/covered"">
+    <coverage type=""line, %"" value=""100% (4/4)"" />
+   </srcfile>
+  </all>
+ </data>
+</report>
+";
+
+            var result = transformer.Transform(summary);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
This PR attempts to solve issue #403 by using the Emma XML format (schema example [here](http://emma.sourceforge.net/coverage_sample_c/coverage.xml)).

The new transformer has 100% coverage.

I tested this in a local installation of Jenkins (version 1.646, Emma version 1.29) for a project of mine and got the following output:

![jenkins](https://cloud.githubusercontent.com/assets/5374887/12700231/76933904-c7b9-11e5-957e-1691ba168da0.png)

The fact that the results are placed in the "method" column seems to be an issue with Emma. The numeric values actually correspond to the "line" column.

I don't think Chutzpah distinguishes between packages, classes and files; therefore, I'm not considering per-package or per-class coverage, only per-file coverage. Let me know whether you'd like me to consider a folder a "package".
