### PR TITLE
Abort test execution if the Chutzpah.json file is malformed

### DIFF
--- a/Chutzpah/ChutzpahTestSettingsService.cs
+++ b/Chutzpah/ChutzpahTestSettingsService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection.Emit;
 using Chutzpah.Models;
 using Chutzpah.Wrappers;
+using Chutzpah.Exceptions;
 
 namespace Chutzpah
 {
@@ -107,15 +108,22 @@ namespace Chutzpah
                 else if (!ChutzpahSettingsFileCache.TryGetValue(Path.GetDirectoryName(testSettingsFilePath), out settings))
                 {
                     ChutzpahTracer.TraceInformation("Chutzpah.json file found at {0} given starting directory {1}", testSettingsFilePath, directory);
-                    settings = serializer.DeserializeFromFile<ChutzpahTestSettingsFile>(testSettingsFilePath);
-
-                    if (settings == null)
+                    try
                     {
-                        settings = ChutzpahTestSettingsFile.Default;
+                        settings = serializer.DeserializeFromFile<ChutzpahTestSettingsFile>(testSettingsFilePath);
+                        if (settings == null)
+                        {
+                            settings = ChutzpahTestSettingsFile.Default;
+                        }
+                        else
+                        {
+                            settings.IsDefaultSettings = false;
+                        }
                     }
-                    else
+                    catch (Exception e)
                     {
-                        settings.IsDefaultSettings = false;
+                        ChutzpahTracer.TraceError("Error parsing Chutzpah.json: {0}", e.Message);
+                        throw new ChutzpahException("Error parsing Chutzpah.json: " + e.Message);
                     }
 
                     settings.SettingsFileDirectory = Path.GetDirectoryName(testSettingsFilePath);

--- a/Facts.Integration/Execution.cs
+++ b/Facts.Integration/Execution.cs
@@ -1033,6 +1033,14 @@ namespace Chutzpah.Facts.Integration
                 Assert.Equal(1, result.PassedCount);
                 Assert.Equal(1, result.TotalCount);
             }
+
+            [Fact]
+            public void Will_throw_if_malformed_json()
+            {
+                var testRunner = TestRunner.Create();
+
+                Assert.Throws<ChutzpahException>(() => testRunner.RunTests(@"JS\Test\TestSettings\Malformed\ReferencesTests.js", new ExceptionThrowingRunnerCallback()));
+            }
         }
     }
 }

--- a/Facts.Integration/Facts.Integration.csproj
+++ b/Facts.Integration/Facts.Integration.csproj
@@ -350,6 +350,21 @@
     <Content Include="JS\Test\TestSettings\Lcov\lcov.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="JS\Test\TestSettings\Malformed\Lib\skipThis.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="JS\Test\TestSettings\Malformed\Lib\someLib.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="JS\Test\TestSettings\Malformed\Lib\takeThis.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="JS\Test\TestSettings\Malformed\localFile.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="JS\Test\TestSettings\Malformed\ReferencesTests.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="JS\Test\TestSettings\ReferencePaths\Lib\skipThis.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -503,6 +518,9 @@
     <None Include="JS\Test\TestSettings\Batching\Ambiguous1\chutzpah.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="JS\Test\TestSettings\Malformed\chutzpah.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="JS\Test\TestSettings\TestPathsMultipleIncludeExclude\chutzpah.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Facts.Integration/JS/Test/TestSettings/Malformed/Lib/skipThis.js
+++ b/Facts.Integration/JS/Test/TestSettings/Malformed/Lib/skipThis.js
@@ -1,0 +1,1 @@
+﻿var skipThis = true;

--- a/Facts.Integration/JS/Test/TestSettings/Malformed/Lib/someLib.js
+++ b/Facts.Integration/JS/Test/TestSettings/Malformed/Lib/someLib.js
@@ -1,0 +1,5 @@
+﻿someLib = {    
+    hello: function() {
+        return "Hello there";
+    }  
+};

--- a/Facts.Integration/JS/Test/TestSettings/Malformed/Lib/takeThis.js
+++ b/Facts.Integration/JS/Test/TestSettings/Malformed/Lib/takeThis.js
@@ -1,0 +1,1 @@
+﻿var takeThis = true;

--- a/Facts.Integration/JS/Test/TestSettings/Malformed/ReferencesTests.js
+++ b/Facts.Integration/JS/Test/TestSettings/Malformed/ReferencesTests.js
@@ -1,0 +1,9 @@
+﻿describe("some suite", function() {
+    it("should have referenced chai", function() {
+        chai.expect(chai).to.exist;
+    });
+    it("Will include files from folder", function () {
+        chai.expect(takeThis).to.equal(true);
+        chai.expect(typeof skipThis).to.equal("undefined");
+    });
+});

--- a/Facts.Integration/JS/Test/TestSettings/Malformed/chutzpah.json
+++ b/Facts.Integration/JS/Test/TestSettings/Malformed/chutzpah.json
@@ -1,0 +1,8 @@
+﻿{
+    "Framework": "mocha",
+	"References": [
+		{ "Path": "../../chai.js" }
+	    { "Path": "localFile.js"},
+	    { "Path": "Lib", "Include": "*Take*", "Exclude": "*Skip*" }
+	]
+}

--- a/Facts.Integration/JS/Test/TestSettings/Malformed/localFile.js
+++ b/Facts.Integration/JS/Test/TestSettings/Malformed/localFile.js
@@ -1,0 +1,1 @@
+﻿globalValue = "expected value";


### PR DESCRIPTION
This PR provides a fix for issue #462. When parsing a malformed Chutzpah.json file, it will throw an exception and abort test execution. It will show a message similar to the following:

`Chutzpah.Exceptions.ChutzpahException: Error parsing Chutzpah.json: After parsing a value an unexpected character was encountered: {. Path 'References[0]', line 9, position 9.`