### PR TITLE
Fix typescript reference issue

### DIFF
--- a/Chutzpah/BatchCompiler/BatchCompilerService.cs
+++ b/Chutzpah/BatchCompiler/BatchCompilerService.cs
@@ -179,24 +179,22 @@ namespace Chutzpah.BatchProcessor
         {
             foreach (var pathMap in compileConfiguration.Paths)
             {
-                if (filePath.IndexOf(pathMap.SourcePath, StringComparison.OrdinalIgnoreCase) >= 0)
+                // If the configured sourcePath is a full file path we just assume the fileName is the relative name
+                // Otherwise we calculate the relative path from the configured sourcePath to the current file
+                var relativePath = pathMap.SourcePathIsFile ? Path.GetFileName(pathMap.SourcePath) : FileProbe.GetRelativePath(pathMap.SourcePath, filePath);
+
+                string outputPath = pathMap.OutputPath;
+                if (!pathMap.OutputPathIsFile)
                 {
-                    // If the configured sourcePath is a full file path we just assume the fileName is the relative name
-                    // Otherwise we calculate the relative path from the configured sourcePath to the current file
-                    var relativePath = pathMap.SourcePathIsFile ? Path.GetFileName(pathMap.SourcePath) : FileProbe.GetRelativePath(pathMap.SourcePath, filePath);
+                    // If output path is not a file we calculate the file path using the input filePath's relative location compared
+                    // to the output directory
+                    outputPath = Path.Combine(outputPath, relativePath);
+                    outputPath = Path.ChangeExtension(outputPath, ".js");
+                    outputPath = Path.GetFullPath(outputPath);
 
-                    string outputPath = pathMap.OutputPath;
-                    if (!pathMap.OutputPathIsFile)
-                    {
-                        // If output path is not a file we calculate the file path using the input filePath's relative location compared
-                        // to the output directory
-                        outputPath = Path.Combine(outputPath, relativePath);
-                        outputPath = Path.ChangeExtension(outputPath, ".js");
-
-                    }
-
-                    return outputPath;
                 }
+
+                return outputPath;
             }
 
             ChutzpahTracer.TraceError("Can't find location for generated path on {0}",filePath);


### PR DESCRIPTION
Given C:\path\to\src\chutzpah.json
And the command C:\path\to\src>ctz chutzpah.json
```
{
  ... other options removed for brevity ...
  "Compile": {
    "UseSourceMaps": true,
    "Mode": "External",
    "Extensions": [ ".ts" ],
    "ExtensionsWithNoOutput": [ ".d.ts" ]
  },
  "References": [
    { "Path": "tests/mocks.ts" },
    { "Path": "../../other-src/code.ts" }
  ]
}
```

I want the chutzpah to build the following references in the harness:
```
<script href="file:///C:/path/to/src/tests/mocks.js"></script>
<script href="file:///C:/path/other-src/code.ts"></script>
```

At present it omits the second Reference as its absolute path does not
start with the directory path of the chutzpah.json file
(BatchCompilerService : line 182)

P.S. I would have written tests against this case, but I couldnt install
the xUnit test runner. The VISX installer crashed.