### PR TITLE
Fix AmdFilePath when path contains file extension

### DIFF
--- a/Chutzpah/ReferenceProcessor.cs
+++ b/Chutzpah/ReferenceProcessor.cs
@@ -176,13 +176,16 @@ namespace Chutzpah
         {
             string amdModulePath = UrlBuilder.GetRelativePath(amdAppRoot, filePath);
 
-            amdModulePath = amdModulePath
-                .Replace(Path.GetExtension(filePath), "")
-                .Replace("\\", "/")
-                .Trim('/', '\\');
-
+            amdModulePath = NormalizeAmdModulePath(amdModulePath);
 
             return amdModulePath;
+        }
+
+        private static string NormalizeAmdModulePath(string path)
+        {
+            return Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path))
+                .Replace("\\", "/")
+                .Trim('/', '\\');
         }
 
         /// <summary>
@@ -215,11 +218,7 @@ namespace Chutzpah
         {
             string amdModulePath = UrlBuilder.GetRelativePath(testHarnessDirectory, filePath);
 
-            amdModulePath = Path.Combine(relativeAmdRootPath, amdModulePath)
-                .Replace(Path.GetExtension(filePath), "")
-                .Replace("\\", "/")
-                .Trim('/', '\\');
-
+            amdModulePath = NormalizeAmdModulePath(Path.Combine(relativeAmdRootPath, amdModulePath));
 
             return amdModulePath;
         }

--- a/Facts/Library/ReferenceProcessorFacts.cs
+++ b/Facts/Library/ReferenceProcessorFacts.cs
@@ -80,6 +80,38 @@ namespace Chutzpah.Facts
 
 
             [Fact]
+            public void Will_not_replace_directory_name_containing_extension_in_relative_amd_path()
+            {
+                var processor = new TestableReferenceProcessor();
+                var testHarnessDirectory = @"c:\some\src\folder";
+                var referencedFile = new ReferencedFile { Path = @"C:\some\path.jstests\code\test.js" };
+                var referenceFiles = new List<ReferencedFile> { referencedFile };
+                var settings = new ChutzpahTestSettingsFile { };
+
+                processor.ClassUnderTest.SetupAmdFilePaths(referenceFiles, testHarnessDirectory, settings);
+
+                Assert.Equal("../../path.jstests/code/test", referencedFile.AmdFilePath);
+                Assert.Null(referencedFile.AmdGeneratedFilePath);
+            }
+
+
+            [Fact]
+            public void Will_not_replace_directory_name_containing_extension_in_relative_amd_path_with_legacy_setting()
+            {
+                var processor = new TestableReferenceProcessor();
+                var testHarnessDirectory = @"c:\some\src\folder";
+                var referencedFile = new ReferencedFile { Path = @"C:\some\path.jstests\code\test.js" };
+                var referenceFiles = new List<ReferencedFile> { referencedFile };
+                var settings = new ChutzpahTestSettingsFile { AMDBasePath = @"C:\some\other" };
+
+                processor.ClassUnderTest.SetupAmdFilePaths(referenceFiles, testHarnessDirectory, settings);
+
+                Assert.Equal("../src/folder/../../path.jstests/code/test", referencedFile.AmdFilePath);
+                Assert.Null(referencedFile.AmdGeneratedFilePath);
+            }
+
+
+            [Fact]
             public void Will_make_amd_path_relative_to_amdbasepath_with_legacy_setting()
             {
                 var processor = new TestableReferenceProcessor();


### PR DESCRIPTION
Given that path contains a substring identical to the file extension,
AmdPath was incorrect.

This commit will make sure only the file extension is removed when
setting AmdFilePath.