### PR TITLE
Add support of proxy setting

### DIFF
--- a/Chutzpah/Chutzpah.csproj
+++ b/Chutzpah/Chutzpah.csproj
@@ -351,6 +351,7 @@
     <Compile Include="Utility\Hasher.cs" />
     <Compile Include="Utility\IHasher.cs" />
     <Compile Include="Utility\ProcessExtensions.cs" />
+    <Compile Include="Utility\ValidationHelper.cs" />
     <Compile Include="Wrappers\EnvironmentWrapper.cs" />
     <Compile Include="Wrappers\FileSystemWrapper.cs" />
     <Compile Include="Wrappers\HtmlUtility.cs" />

--- a/Chutzpah/ChutzpahTestSettingsService.cs
+++ b/Chutzpah/ChutzpahTestSettingsService.cs
@@ -133,6 +133,8 @@ namespace Chutzpah
 
                     ProcessServerSettings(settings, chutzpahVariables);
 
+                    ProcessProxy(settings, chutzpahVariables);
+
                     ProcessInheritance(environment, settings, chutzpahVariables);
 
                     if (!forceFresh)
@@ -186,6 +188,20 @@ namespace Chutzpah
             }
         }
 
+        private void ProcessProxy(ChutzpahTestSettingsFile settings, IDictionary<string, string> chutzpahVariables)
+        {
+            if (!string.IsNullOrEmpty(settings.Proxy))
+            {
+                var validProxyPattern = @".*:[\d]+$";
+                if (string.IsNullOrEmpty(settings.Proxy) || !System.Text.RegularExpressions.Regex.IsMatch(settings.Proxy, validProxyPattern))
+                {
+                    ChutzpahTracer.TraceInformation("invalid proxy, must be in format of address:port");
+                }else
+                {
+                    ChutzpahTracer.TraceInformation(string.Format("Proxy setting:{0}", settings.Proxy));
+                }
+            }
+        }
         private void ProcessInheritance(ChutzpahSettingsFileEnvironment environment, ChutzpahTestSettingsFile settings, IDictionary<string, string> chutzpahVariables)
         {
             if (settings.InheritFromParent || !string.IsNullOrEmpty(settings.InheritFromPath))

--- a/Chutzpah/ChutzpahTestSettingsService.cs
+++ b/Chutzpah/ChutzpahTestSettingsService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection.Emit;
 using Chutzpah.Models;
 using Chutzpah.Wrappers;
+using Chutzpah.Utility;
 
 namespace Chutzpah
 {
@@ -192,11 +193,12 @@ namespace Chutzpah
         {
             if (!string.IsNullOrEmpty(settings.Proxy))
             {
-                var validProxyPattern = @".*:[\d]+$";
-                if (string.IsNullOrEmpty(settings.Proxy) || !System.Text.RegularExpressions.Regex.IsMatch(settings.Proxy, validProxyPattern))
+                if (!ValidationHelper.IsValidProxySetting(settings.Proxy))
                 {
+                    settings.Proxy = string.Empty;
                     ChutzpahTracer.TraceInformation("invalid proxy, must be in format of address:port");
-                }else
+                }
+                else
                 {
                     ChutzpahTracer.TraceInformation(string.Format("Proxy setting:{0}", settings.Proxy));
                 }

--- a/Chutzpah/Models/ChutzpahTestSettingsFile.cs
+++ b/Chutzpah/Models/ChutzpahTestSettingsFile.cs
@@ -326,6 +326,11 @@ namespace Chutzpah.Models
             }
         }
 
+        /// <summary>
+        /// Allow configure the optional proxy setting for the headless browser in format of [address]:[port]
+        /// If not set, the default is no proxy
+        /// </summary>
+        public string Proxy { get; set; }
 
         public string SettingsFileName
         {
@@ -468,7 +473,7 @@ namespace Chutzpah.Models
             this.EnableTracing = this.EnableTracing ?? parent.EnableTracing;
             this.TraceFilePath = this.TraceFilePath ?? parent.TraceFilePath;
             this.CodeCoverageTimeout = this.CodeCoverageTimeout ?? parent.CodeCoverageTimeout;
-            
+            this.Proxy = this.Proxy ?? parent.Proxy;
 
             // Deprecated
             this.AMDBasePath = this.AMDBasePath ?? parent.AMDBasePath;

--- a/Chutzpah/TestOptions.cs
+++ b/Chutzpah/TestOptions.cs
@@ -89,5 +89,10 @@ namespace Chutzpah
         /// the settings file
         /// </summary>
         public ChutzpahSettingsFileEnvironments ChutzpahSettingsFileEnvironments { get; set; }
+
+        /// <summary>
+        /// Optional proxy settings in format of [address]:[port]
+        /// </summary>
+        public string Proxy { get; set; }
     }
 }

--- a/Chutzpah/TestRunner.cs
+++ b/Chutzpah/TestRunner.cs
@@ -684,7 +684,8 @@ namespace Chutzpah
             string runnerArgs;
             var testModeStr = testExecutionMode.ToString().ToLowerInvariant();
             var timeout = context.TestFileSettings.TestFileTimeout ?? options.TestFileTimeoutMilliseconds ?? Constants.DefaultTestFileTimeout;
-            var proxySetting = string.IsNullOrEmpty(options.Proxy) ? (string.IsNullOrEmpty(context.TestFileSettings.Proxy)?"--proxy-type=none": string.Format("--proxy={0}", context.TestFileSettings.Proxy)) : string.Format("--proxy={0}",options.Proxy);
+            var proxy = options.Proxy ?? context.TestFileSettings.Proxy;
+            var proxySetting = string.IsNullOrEmpty(proxy) ? "--proxy-type=none" : string.Format("--proxy={0}", proxy);
             runnerArgs = string.Format("--ignore-ssl-errors=true {0} --ssl-protocol=any \"{1}\" {2} {3} {4} {5} {6}",
                                        proxySetting,
                                        runnerPath,

--- a/Chutzpah/TestRunner.cs
+++ b/Chutzpah/TestRunner.cs
@@ -684,8 +684,8 @@ namespace Chutzpah
             string runnerArgs;
             var testModeStr = testExecutionMode.ToString().ToLowerInvariant();
             var timeout = context.TestFileSettings.TestFileTimeout ?? options.TestFileTimeoutMilliseconds ?? Constants.DefaultTestFileTimeout;
-
-            runnerArgs = string.Format("--ignore-ssl-errors=true --proxy-type=none --ssl-protocol=any \"{0}\" {1} {2} {3} {4} {5}",
+            runnerArgs = string.Format("--ignore-ssl-errors=true {0} --ssl-protocol=any \"{1}\" {2} {3} {4} {5} {6}",
+                                       proxySetting,
                                        runnerPath,
                                        fileUrl,
                                        testModeStr,

--- a/Chutzpah/TestRunner.cs
+++ b/Chutzpah/TestRunner.cs
@@ -684,6 +684,7 @@ namespace Chutzpah
             string runnerArgs;
             var testModeStr = testExecutionMode.ToString().ToLowerInvariant();
             var timeout = context.TestFileSettings.TestFileTimeout ?? options.TestFileTimeoutMilliseconds ?? Constants.DefaultTestFileTimeout;
+            var proxySetting = string.IsNullOrEmpty(options.Proxy) ? (string.IsNullOrEmpty(context.TestFileSettings.Proxy)?"--proxy-type=none": string.Format("--proxy={0}", context.TestFileSettings.Proxy)) : string.Format("--proxy={0}",options.Proxy);
             runnerArgs = string.Format("--ignore-ssl-errors=true {0} --ssl-protocol=any \"{1}\" {2} {3} {4} {5} {6}",
                                        proxySetting,
                                        runnerPath,

--- a/Chutzpah/Utility/ValidationHelper.cs
+++ b/Chutzpah/Utility/ValidationHelper.cs
@@ -11,8 +11,8 @@ namespace Chutzpah.Utility
         private const string ValidProxyPattern = @".*:[\d]+$";
         public static bool IsValidProxySetting(string value)
         {
-            return (string.IsNullOrEmpty(value) || 
-                !System.Text.RegularExpressions.Regex.IsMatch(value, ValidProxyPattern));
+            return (!string.IsNullOrEmpty(value) &&
+                System.Text.RegularExpressions.Regex.IsMatch(value, ValidProxyPattern));
         }
     }
 }

--- a/Chutzpah/Utility/ValidationHelper.cs
+++ b/Chutzpah/Utility/ValidationHelper.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Chutzpah.Utility
+{
+    public class ValidationHelper
+    {
+        private const string ValidProxyPattern = @".*:[\d]+$";
+        public static bool IsValidProxySetting(string value)
+        {
+            return (string.IsNullOrEmpty(value) || 
+                !System.Text.RegularExpressions.Regex.IsMatch(value, ValidProxyPattern));
+        }
+    }
+}

--- a/ConsoleRunner/CommandLine.cs
+++ b/ConsoleRunner/CommandLine.cs
@@ -254,7 +254,7 @@ namespace Chutzpah
 
         private void AddProxy(string value)
         {
-            if (ValidationHelper.IsValidProxySetting(value))
+            if (!ValidationHelper.IsValidProxySetting(value))
             {
                 throw new ArgumentException(
                     "invalid proxy, must be in format of address:port");

--- a/ConsoleRunner/CommandLine.cs
+++ b/ConsoleRunner/CommandLine.cs
@@ -69,6 +69,8 @@ namespace Chutzpah
 
         public string BrowserArgs { get; protected set; }
 
+        public string Proxy { get; protected set; }
+
         private static void GuardNoOptionValue(KeyValuePair<string, string> option)
         {
             if (option.Value != null)
@@ -147,6 +149,9 @@ namespace Chutzpah
                 case "/file":
                 case "/path":
                     AddFileOption(option.Value);
+                    break;
+                case "/proxy":
+                    AddProxy(option.Value);
                     break;
                 case "/vsoutput":
                     GuardNoOptionValue(option);
@@ -244,6 +249,18 @@ namespace Chutzpah
             }
 
             TimeOutMilliseconds = timeout;
+        }
+
+        private void AddProxy(string value)
+        {
+            var validProxyPattern = @".*:[\d]+$";
+            if (string.IsNullOrEmpty(value) || !System.Text.RegularExpressions.Regex.IsMatch(value, validProxyPattern))
+            {
+                throw new ArgumentException(
+                    "invalid proxy, must be in format of address:port");
+            }
+
+            Proxy = value;
         }
 
         private void AddBrowserName(string value)

--- a/ConsoleRunner/CommandLine.cs
+++ b/ConsoleRunner/CommandLine.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using Chutzpah.Models;
+using Chutzpah.Utility;
 
 namespace Chutzpah
 {
@@ -253,8 +254,7 @@ namespace Chutzpah
 
         private void AddProxy(string value)
         {
-            var validProxyPattern = @".*:[\d]+$";
-            if (string.IsNullOrEmpty(value) || !System.Text.RegularExpressions.Regex.IsMatch(value, validProxyPattern))
+            if (ValidationHelper.IsValidProxySetting(value))
             {
                 throw new ArgumentException(
                     "invalid proxy, must be in format of address:port");

--- a/ConsoleRunner/Program.cs
+++ b/ConsoleRunner/Program.cs
@@ -117,6 +117,7 @@ namespace Chutzpah
             Console.WriteLine("  /settingsFileEnvironment     : Sets the environment properties for a chutzpah.json settings file.");
             Console.WriteLine("                               : Specify more than one to add multiple environments.");
             Console.WriteLine("                               : (e.g. settingsFilePath;prop1=val1;prop2=val2).");
+            Console.WriteLine("  /proxy                       : Sets the proxy server and port if the test require reference to external uri.");
 
 
 
@@ -157,6 +158,7 @@ namespace Chutzpah
                         BrowserArgs = commandLine.BrowserArgs,
                         TestFileTimeoutMilliseconds = commandLine.TimeOutMilliseconds,
                         ChutzpahSettingsFileEnvironments = commandLine.SettingsFileEnvironments,
+                        Proxy = commandLine.Proxy,
                         CoverageOptions = new CoverageOptions
                                               {
                                                   Enabled = commandLine.Coverage,

--- a/Facts/ConsoleRunner/CommandLineFacts.cs
+++ b/Facts/ConsoleRunner/CommandLineFacts.cs
@@ -125,6 +125,47 @@ namespace Chutzpah.Facts.ConsoleRunner
             }
         }
 
+        public class ProxyOptionFacts
+        {
+            [Fact]
+            public void Will_Add_IP_Proxy()
+            {
+                var arguments = new[] { "/Proxy", "127.0.0.1:8080" };
+
+                var commandLine = TestableCommandLine.Create(arguments);
+                Assert.Equal("127.0.0.1:8080", commandLine.Proxy);
+            }
+
+            [Fact]
+            public void Will_Add_Host_Proxy()
+            {
+                var arguments = new[] { "/Proxy", "proxy:8080" };
+
+                var commandLine = TestableCommandLine.Create(arguments);
+                Assert.Equal("proxy:8080", commandLine.Proxy);
+            }
+
+            [Fact]
+            public void Will_throw_if_no_proxy_given()
+            {
+                var arguments = new[] { "/Proxy", "" };
+
+                var ex = Record.Exception(() => TestableCommandLine.Create(arguments)) as ArgumentException;
+
+                Assert.NotNull(ex);
+            }
+
+            [Fact]
+            public void Will_throw_if_no_port_given()
+            {
+                var arguments = new[] { "/Proxy", "127.0.0.1" };
+
+                var ex = Record.Exception(() => TestableCommandLine.Create(arguments)) as ArgumentException;
+
+                Assert.NotNull(ex);
+            }
+        }
+
         public class ShowFailureReportOptionFacts
         {
             [Fact]

--- a/Samples/Basic/Jasmine/chutzpah.json
+++ b/Samples/Basic/Jasmine/chutzpah.json
@@ -9,7 +9,6 @@
     ],
     "Server": {
     	"Enabled": true
-    },
-    "Proxy":"127.1.1.1:8080"
+    }
 }
 }

--- a/Samples/Basic/Jasmine/chutzpah.json
+++ b/Samples/Basic/Jasmine/chutzpah.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "Framework": "jasmine",
     "TestHarnessLocationMode": "SettingsFileAdjacent",
     "References" : [
@@ -9,6 +9,7 @@
     ],
     "Server": {
     	"Enabled": true
-    }
+    },
+    "Proxy":"127.1.1.1:8080"
 }
 }


### PR DESCRIPTION
Add support of proxy setting to headless browser in test runner. The
"Proxy" can be passed in either console runner or json setting file in
the format of [address/host]:[port]. If not provided, it will fall back
to default none proxy setting.