### PR TITLE
use the file name as the script tag ID

### DIFF
--- a/Chutzpah/TestHarness.cs
+++ b/Chutzpah/TestHarness.cs
@@ -382,7 +382,7 @@ namespace Chutzpah
 
             if(referencedFile.TemplateOptions.Mode == TemplateMode.Script)
             {
-                contents = string.Format(scriptTagWrapper, referencedFile.TemplateOptions.Id, referencedFile.TemplateOptions.Type, contents);
+                contents = string.Format(scriptTagWrapper, referencedFile.TemplateOptions.Id ?? referencedFile.Path, referencedFile.TemplateOptions.Type, contents);
             }
         }
 


### PR DESCRIPTION
I have multiple templates that I pull in from html files. Giving them all the same ID doesn't help, so my only option is to hard-code all 20 of my references and update them every time a developer renames or makes a new one.

If you take this simple change, I can then use an initialization js script to format the ID the way I want (lower case and replace / with -, but that's on me).

TLDR: same hard-coded ID is slightly limited.