### PR TITLE
#672: Fix for the Chutzpah doesn't discover JS tests in which AmdPaths with Pascal case for the test modules are added

### DIFF
--- a/Chutzpah/FileProbe.cs
+++ b/Chutzpah/FileProbe.cs
@@ -163,7 +163,7 @@ namespace Chutzpah
 
                 // The path we assume default to the chuzpah.json directory if the Path property is not set
                 var testPath = string.IsNullOrEmpty(pathSettings.Path) ? pathSettings.SettingsFileDirectory : pathSettings.Path;
-                testPath = UrlBuilder.NormalizeFilePath(testPath);
+                testPath = UrlBuilder.NormalizeFilePath(testPath, false);
                 testPath = testPath != null ? Path.Combine(pathSettings.SettingsFileDirectory, testPath) : null;
 
                 // If a file path is given just return that file


### PR DESCRIPTION
Issue:
We have one project which has amdPath added for each JS files ( including test files). When I tried running tests using chutzpah on the project. I found that some portion of amdPath generated by chutzpah for the test files is still coming in lower case.

While I can see that as part of commit “5145879: fix path casing” done on 12 Nov 2017, @mmanela fixed most of the casing issue in the test file path generation. but we are still hitting into the test file path casing issue.

Fix
=====
Passing  lowerCase flag = false to NormalizeFilePath in the method FindScriptFiles()