### PR TITLE
Maintain whitespaces of the code in the generated coverage report

### DIFF
--- a/Chutzpah/Coverage/CoverageOutputGenerator.cs
+++ b/Chutzpah/Coverage/CoverageOutputGenerator.cs
@@ -210,7 +210,7 @@ namespace Chutzpah.Coverage
 
 .chutzpah-source div
 {
-  white-space:nowrap;
+  white-space:pre;
 }
 
 .chutzpah-source span


### PR DESCRIPTION
The code in the coverage html generated by Chutzpah shows as if it has no indentation in the browser. This change will make the browser preserve the whitespaces.