### PR TITLE
Fix issue #602 wrong number of tests displayed by TeamCity

### DIFF
--- a/Chutzpah/Callbacks/ITestMethodRunnerCallback.cs
+++ b/Chutzpah/Callbacks/ITestMethodRunnerCallback.cs
@@ -6,40 +6,57 @@ namespace Chutzpah
     public interface ITestMethodRunnerCallback
     {
         /// <summary>
+        /// Started the TestContext in which the test is run
+        /// </summary>
+        /// <param name="context"></param>
+        void TestContextStarted(TestContext context);
+
+        /// <summary>
+        /// Finished the TestContext in which the test is run
+        /// </summary>
+        /// <param name="context"></param>
+        void TestContextFinished(TestContext context);
+
+        /// <summary>
         /// Started running all files containing tests
         /// </summary>
-        void TestSuiteStarted();
+        void TestSuiteStarted(TestContext testContext);
 
         /// <summary>
         /// Finished running all files containing tests
         /// </summary>
+        /// <param name="testContext"></param>
         /// <param name="testResultsSummary"></param>
-        void TestSuiteFinished(TestCaseSummary testResultsSummary);
+        void TestSuiteFinished(TestContext testContext, TestCaseSummary testResultsSummary);
 
         /// <summary>
         /// Began executing tests in a file
         /// </summary>
+        /// <param name="testContext"></param>
         /// <param name="fileName"></param>
-        void FileStarted(string fileName);
+        void FileStarted(TestContext testContext);
 
         /// <summary>
         /// All tests in a file have finished
         /// </summary>
+        /// <param name="testContext"></param>
         /// <param name="fileName"></param>
         /// <param name="testResultsSummary"></param>
-        void FileFinished(string fileName, TestFileSummary testResultsSummary);
+        void FileFinished(TestContext testContext, TestFileSummary testResultsSummary);
 
         /// <summary>
         /// A test started execution
         /// </summary>
+        /// <param name="testContext"></param>
         /// <param name="testCase"></param>
-        void TestStarted(TestCase testCase);
+        void TestStarted(TestContext testContext, TestCase testCase);
 
         /// <summary>
         /// A test finished executing
         /// </summary>
+        /// <param name="testContext"></param>
         /// <param name="testCase"></param>
-        void TestFinished(TestCase testCase);
+        void TestFinished(TestContext testContext, TestCase testCase);
 
         /// <summary>
         /// An exception occurred in Chutzpah while running tests
@@ -51,13 +68,15 @@ namespace Chutzpah
         /// <summary>
         /// An error that occurred in a test file 
         /// </summary>
+        /// <param name="testContext"></param>
         /// <param name="error">Test file error</param>
-        void FileError(TestError error);
+        void FileError(TestContext testContext, TestError error);
 
         /// <summary>
         /// An log message sent from a test file 
         /// </summary>
+        /// <param name="testContext"></param>
         /// <param name="log">Test file log message</param>
-        void FileLog(TestLog log);
+        void FileLog(TestContext testContext, TestLog log);
     }
 }

--- a/Chutzpah/Callbacks/ParallelRunnerCallbackAdapter.cs
+++ b/Chutzpah/Callbacks/ParallelRunnerCallbackAdapter.cs
@@ -16,51 +16,67 @@ namespace Chutzpah.Callbacks
             this.nestedCallback = nestedCallback;
         }
 
-        public void TestSuiteStarted()
+        public void TestContextStarted(TestContext context)
         {
             lock (sync)
             {
-                nestedCallback.TestSuiteStarted();
+                nestedCallback.TestContextStarted(context);
             }
         }
 
-        public void TestSuiteFinished(TestCaseSummary testResultsSummary)
+        public void TestContextFinished(TestContext context)
         {
             lock (sync)
             {
-                nestedCallback.TestSuiteFinished(testResultsSummary);
+                nestedCallback.TestContextFinished(context);
             }
         }
 
-        public void FileStarted(string fileName)
+        public void TestSuiteStarted(TestContext context)
         {
             lock (sync)
             {
-                nestedCallback.FileStarted(fileName);
+                nestedCallback.TestSuiteStarted(context);
             }
         }
 
-        public void FileFinished(string fileName, TestFileSummary testResultsSummary)
+        public void TestSuiteFinished(TestContext context, TestCaseSummary testResultsSummary)
         {
             lock (sync)
             {
-                nestedCallback.FileFinished(fileName, testResultsSummary);
+                nestedCallback.TestSuiteFinished(context, testResultsSummary);
             }
         }
 
-        public void TestStarted(TestCase testCase)
+        public void FileStarted(TestContext context)
         {
             lock (sync)
             {
-                nestedCallback.TestStarted(testCase);
+                nestedCallback.FileStarted(context);
             }
         }
 
-        public void TestFinished(TestCase testCase)
+        public void FileFinished(TestContext context, TestFileSummary testResultsSummary)
         {
             lock (sync)
             {
-                nestedCallback.TestFinished(testCase);
+                nestedCallback.FileFinished(context, testResultsSummary);
+            }
+        }
+
+        public void TestStarted(TestContext context, TestCase testCase)
+        {
+            lock (sync)
+            {
+                nestedCallback.TestStarted(context, testCase);
+            }
+        }
+
+        public void TestFinished(TestContext context, TestCase testCase)
+        {
+            lock (sync)
+            {
+                nestedCallback.TestFinished(context, testCase);
             }
         }
 
@@ -72,19 +88,19 @@ namespace Chutzpah.Callbacks
             }
         }
 
-        public void FileError(TestError error)
+        public void FileError(TestContext context, TestError error)
         {
             lock (sync)
             {
-                nestedCallback.FileError(error);
+                nestedCallback.FileError(context, error);
             }
         }
 
-        public void FileLog(TestLog log)
+        public void FileLog(TestContext context, TestLog log)
         {
             lock (sync)
             {
-                nestedCallback.FileLog(log);
+                nestedCallback.FileLog(context, log);
             }
         }
     }

--- a/Chutzpah/Callbacks/RunnerCallback.cs
+++ b/Chutzpah/Callbacks/RunnerCallback.cs
@@ -19,43 +19,48 @@ namespace Chutzpah
             }
         }
 
-        public virtual void TestSuiteStarted() { }
-        public virtual void TestSuiteFinished(TestCaseSummary testResultsSummary) { }
-        public virtual void FileStarted(string fileName) { }
+        public virtual void TestContextStarted(TestContext context) { }
+        public virtual void TestContextFinished(TestContext context) { }
 
-        public virtual void FileFinished(string fileName, TestFileSummary testResultsSummary){}
+        public virtual void TestSuiteStarted(TestContext context) { }
+        public virtual void TestSuiteFinished(TestContext context,TestCaseSummary testResultsSummary) { }
 
-        public virtual void TestStarted(TestCase testCase) { }
+        public virtual void FileStarted(TestContext context) { }
+        public virtual void FileFinished(TestContext context, TestFileSummary testResultsSummary) { }
+
         public virtual void ExceptionThrown(Exception exception, string fileName) { }
-        public virtual void FileError(TestError error) { }
-        public virtual void FileLog(TestLog log) { }
-        public virtual void TestFinished(TestCase testCase)
+
+        public virtual void FileError(TestContext context, TestError error) { }
+        public virtual void FileLog(TestContext context, TestLog log) { }
+
+        public virtual void TestStarted(TestContext context, TestCase testCase) { }
+        public virtual void TestFinished(TestContext context, TestCase testCase)
         {
             switch (testCase.TestOutcome)
             {
                 case TestOutcome.Passed:
                     ChutzpahTracer.TraceInformation("File {0}, Test {1} passed", testCase.InputTestFile, testCase.TestName);
-                    TestPassed(testCase);
+                    TestPassed(context, testCase);
                     break;
                 case TestOutcome.Failed: 
                     ChutzpahTracer.TraceInformation("File {0}, Test {1} failed", testCase.InputTestFile, testCase.TestName);
-                    TestFailed(testCase);
+                    TestFailed(context, testCase);
                     break;
                 case TestOutcome.Skipped:
                     ChutzpahTracer.TraceInformation("File {0}, Test {1} skipped", testCase.InputTestFile, testCase.TestName);
-                    TestSkipped(testCase);
+                    TestSkipped(context, testCase);
                     break;
                 default:
                     break;
             }
 
-            TestComplete(testCase);
+            TestComplete(context, testCase);
         }
 
-        protected virtual void TestComplete(TestCase testCase) { }
-        protected virtual void TestFailed(TestCase testCase) { }
-        protected virtual void TestPassed(TestCase testCase) { }
-        protected virtual void TestSkipped(TestCase testCase) { }
+        protected virtual void TestComplete(TestContext context, TestCase testCase) { }
+        protected virtual void TestFailed(TestContext context, TestCase testCase) { }
+        protected virtual void TestPassed(TestContext context, TestCase testCase) { }
+        protected virtual void TestSkipped(TestContext context, TestCase testCase) { }
 
         protected virtual string GetCodeCoverageMessage(CoverageData coverageData)
         {

--- a/Chutzpah/ExecutionProviders/NodeTestExecutionProvider.cs
+++ b/Chutzpah/ExecutionProviders/NodeTestExecutionProvider.cs
@@ -60,7 +60,7 @@ namespace Chutzpah
             var environmentVariables = BuildEnvironmentVariables();
             var processResult = processTools.RunExecutableAndProcessOutput(headlessBrowserPath, runnerArgs, streamProcessor, streamTimeout, environmentVariables);
 
-            HandleTestProcessExitCode(processResult.ExitCode, testContext.FirstInputTestFile, processResult.Model.TestFileSummaries.Select(x => x.Errors).FirstOrDefault(), callback);
+            HandleTestProcessExitCode(testContext, processResult.ExitCode, testContext.FirstInputTestFile, processResult.Model.TestFileSummaries.Select(x => x.Errors).FirstOrDefault(), callback);
 
             return processResult.Model.TestFileSummaries;
         }
@@ -75,7 +75,7 @@ namespace Chutzpah
         }
 
 
-        private static void HandleTestProcessExitCode(int exitCode, string inputTestFile, IList<TestError> errors, ITestMethodRunnerCallback callback)
+        private static void HandleTestProcessExitCode(TestContext context, int exitCode, string inputTestFile, IList<TestError> errors, ITestMethodRunnerCallback callback)
         {
             string errorMessage = null;
 
@@ -102,7 +102,7 @@ namespace Chutzpah
 
                 errors.Add(error);
 
-                callback.FileError(error);
+                callback.FileError(context, error);
                 ChutzpahTracer.TraceError("Headless browser returned with an error: {0}", errorMessage);
             }
         }

--- a/Chutzpah/ExecutionProviders/PhantomTestExecutionProvider.cs
+++ b/Chutzpah/ExecutionProviders/PhantomTestExecutionProvider.cs
@@ -48,13 +48,13 @@ namespace Chutzpah
 
             var processResult = processTools.RunExecutableAndProcessOutput(headlessBrowserPath, runnerArgs, streamProcessor, streamTimeout, null);
 
-            HandleTestProcessExitCode(processResult.ExitCode, testContext.FirstInputTestFile, processResult.Model.TestFileSummaries.Select(x => x.Errors).FirstOrDefault(), callback);
+            HandleTestProcessExitCode(testContext, processResult.ExitCode, testContext.FirstInputTestFile, processResult.Model.TestFileSummaries.Select(x => x.Errors).FirstOrDefault(), callback);
 
             return processResult.Model.TestFileSummaries;
         }
 
 
-        private static void HandleTestProcessExitCode(int exitCode, string inputTestFile, IList<TestError> errors, ITestMethodRunnerCallback callback)
+        private static void HandleTestProcessExitCode(TestContext context, int exitCode, string inputTestFile, IList<TestError> errors, ITestMethodRunnerCallback callback)
         {
             string errorMessage = null;
 
@@ -81,7 +81,7 @@ namespace Chutzpah
 
                 errors.Add(error);
 
-                callback.FileError(error);
+                callback.FileError(context, error);
                 ChutzpahTracer.TraceError("Headless browser returned with an error: {0}", errorMessage);
             }
         }

--- a/Chutzpah/ITestRunner.cs
+++ b/Chutzpah/ITestRunner.cs
@@ -32,7 +32,7 @@ namespace Chutzpah
 
         TestCaseSummary RunTests(string testPath, ITestMethodRunnerCallback callback = null);
         TestCaseSummary RunTests(string testPath, TestOptions options, ITestMethodRunnerCallback callback = null);
-        TestCaseSummary RunTests(IEnumerable<string> testPaths, TestOptions options, ITestMethodRunnerCallback callback = null);
+        TestCaseSummary RunTests(IEnumerable<string> testPaths, TestOptions options, ITestMethodRunnerCallback callback = null, TestContext testContext = null);
         TestCaseSummary RunTests(IEnumerable<string> testPaths, ITestMethodRunnerCallback callback = null);
 
         IEnumerable<TestCase> DiscoverTests(string testPath);

--- a/Chutzpah/Models/TestContext.cs
+++ b/Chutzpah/Models/TestContext.cs
@@ -22,6 +22,11 @@ namespace Chutzpah.Models
         public string FirstInputTestFile { get; set; }
 
         /// <summary>
+        /// The Id of the Task running the TestContext
+        /// </summary>
+        public int TaskId { get; set; }
+
+        /// <summary>
         /// The path to the test runner
         /// </summary>
         public string TestRunner { get; set; }

--- a/Chutzpah/TestRunner.cs
+++ b/Chutzpah/TestRunner.cs
@@ -170,15 +170,16 @@ namespace Chutzpah
         }
 
         public TestCaseSummary RunTests(IEnumerable<string> testPaths,
-                                          TestOptions options,
-                                          ITestMethodRunnerCallback callback = null)
+                                        TestOptions options,
+                                        ITestMethodRunnerCallback callback = null,
+                                        TestContext testContext = null)
         {
             callback = options.TestLaunchMode == TestLaunchMode.FullBrowser || callback == null ? RunnerCallback.Empty : callback;
-            callback.TestSuiteStarted();
+            callback.TestSuiteStarted(testContext);
 
             var testCaseSummary = ProcessTestPaths(testPaths, options, TestExecutionMode.Execution, callback);
 
-            callback.TestSuiteFinished(testCaseSummary);
+            callback.TestSuiteFinished(testContext, testCaseSummary);
             return testCaseSummary;
         }
 
@@ -413,6 +414,7 @@ namespace Chutzpah
                 {
                     ChutzpahTracer.TraceInformation("Start test run for {0} in {1} mode", testContext.FirstInputTestFile, testExecutionMode);
 
+                    testContext.TaskId = Task.CurrentId.HasValue ? Task.CurrentId.Value : 0;
                     try
                     {
                         try
@@ -457,11 +459,15 @@ namespace Chutzpah
                                 testContext.TestHarnessPath,
                                 testContext.FirstInputTestFile);
 
+                            callback.TestContextStarted(testContext);
+
                             var testSummaries = InvokeTestRunner(
                                 options,
                                 testContext,
                                 testExecutionMode,
                                 callback);
+
+                            callback.TestContextFinished(testContext);
 
                             foreach (var testSummary in testSummaries)
                             {
@@ -508,7 +514,7 @@ namespace Chutzpah
                         };
 
                         overallSummary.Errors.Add(error);
-                        callback.FileError(error);
+                        callback.FileError(testContext, error);
 
                         ChutzpahTracer.TraceError(e, "Error during test execution of {0}", testContext.FirstInputTestFile);
                     }
@@ -597,7 +603,7 @@ namespace Chutzpah
                     };
 
                     overallSummary.Errors.Add(error);
-                    callback.FileError(error);
+                    callback.FileError(null, error);
 
                     ChutzpahTracer.TraceError(e, "Error during building test context for {0}", pathString);
                 }

--- a/ConsoleRunner/RunnerCallbacks/ConsoleRunnerCallback.cs
+++ b/ConsoleRunner/RunnerCallbacks/ConsoleRunnerCallback.cs
@@ -14,15 +14,15 @@ namespace Chutzpah.RunnerCallbacks
             Console.Error.Write(GetExceptionThrownMessage(exception, fileName));
         }
 
-        public override void FileError(TestError error)
+        public override void FileError(TestContext context, TestError error)
         {
             var errorMessage = GetFileErrorMessage(error);
             Console.Write(errorMessage);
         }
 
-        public override void TestSuiteFinished(TestCaseSummary testResultsSummary)
+        public override void TestSuiteFinished(TestContext context, TestCaseSummary testResultsSummary)
         {
-            base.TestSuiteFinished(testResultsSummary);
+            base.TestSuiteFinished(context, testResultsSummary);
         }
     }
 }

--- a/ConsoleRunner/RunnerCallbacks/StandardConsoleRunnerCallback.cs
+++ b/ConsoleRunner/RunnerCallbacks/StandardConsoleRunnerCallback.cs
@@ -37,7 +37,7 @@ namespace Chutzpah.RunnerCallbacks
 
         }
 
-        public override void FileLog(TestLog log)
+        public override void FileLog(TestContext context, TestLog log)
         {
             ClearCounter();
 
@@ -46,7 +46,7 @@ namespace Chutzpah.RunnerCallbacks
             Console.ResetColor();
         }
 
-        public override void TestSuiteFinished(TestCaseSummary testResultsSummary)
+        public override void TestSuiteFinished(TestContext context, TestCaseSummary testResultsSummary)
         {
 
             if (testResultsSummary.CoverageObject != null && testResultsSummary.CoverageObject.Any())
@@ -57,7 +57,7 @@ namespace Chutzpah.RunnerCallbacks
 
             if (showFailureReport)
             {
-                PrintErrorReport(testResultsSummary);
+                PrintErrorReport(context, testResultsSummary);
             }
 
 
@@ -73,10 +73,10 @@ namespace Chutzpah.RunnerCallbacks
                 Console.WriteLine("=== {0} total, {1} failed, took {2:n} seconds ===", testResultsSummary.TotalCount, testResultsSummary.FailedCount, seconds);
             }
 
-            base.TestSuiteFinished(testResultsSummary);
+            base.TestSuiteFinished(context, testResultsSummary);
         }
 
-        private void PrintErrorReport(TestCaseSummary testResultsSummary)
+        private void PrintErrorReport(TestContext context, TestCaseSummary testResultsSummary)
         {
             var failedTests = (from testResult in testResultsSummary.Tests 
                               where !testResult.ResultsAllPassed
@@ -91,12 +91,12 @@ namespace Chutzpah.RunnerCallbacks
 
                 foreach (var fileError in fileErrors)
                 {
-                    FileError(fileError);    
+                    FileError(context, fileError);    
                 }
 
                 foreach (var result in failedTests)
                 {
-                    TestFailed(result);
+                    TestFailed(context, result);
                 }
 
 
@@ -104,11 +104,11 @@ namespace Chutzpah.RunnerCallbacks
             }
         }
 
-        public override void FileFinished(string fileName, TestFileSummary testResultsSummary)
+        public override void FileFinished(TestContext context, TestFileSummary testResultsSummary)
         {
             ClearCounter();
 
-            Console.WriteLine("File: {0}", fileName);
+            Console.WriteLine("File: {0}", context.InputTestFilesString);
             var seconds = testResultsSummary.TimeTaken / 1000.0;
             Console.WriteLine(Indent("{0} total, {1} failed, took {2:n} seconds", 2), testResultsSummary.TotalCount, testResultsSummary.FailedCount, seconds);
             Console.WriteLine();
@@ -116,10 +116,10 @@ namespace Chutzpah.RunnerCallbacks
 
             PrintRunningTestCount();
 
-            base.FileFinished(fileName, testResultsSummary);
+            base.FileFinished(context, testResultsSummary);
         }
 
-        protected override void TestFailed(TestCase testCase)
+        protected override void TestFailed(TestContext context, TestCase testCase)
         {
             ClearCounter();
 
@@ -169,7 +169,7 @@ namespace Chutzpah.RunnerCallbacks
             Console.ResetColor();
         }
 
-        public override void FileError(TestError error)
+        public override void FileError(TestContext context, TestError error)
         {
             ClearCounter();
 
@@ -192,7 +192,7 @@ namespace Chutzpah.RunnerCallbacks
             Console.WriteLine(GetCodeCoverageMessage(coverage));
         }
 
-        protected override void TestComplete(TestCase testCase)
+        protected override void TestComplete(TestContext context, TestCase testCase)
         {
             ++testCount;
             PrintRunningTestCount();

--- a/Facts/ConsoleRunner/CallbackFacts.cs
+++ b/Facts/ConsoleRunner/CallbackFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using Chutzpah.Models;
 using Chutzpah.RunnerCallbacks;
 using Xunit;
@@ -35,9 +36,10 @@ namespace Chutzpah.Facts.ConsoleRunner
             [Fact]
             public void It_will_write_file_log_messages_to_console()
             {
+                var ctx = new TestContext { TaskId = 99 };
                 var cb = new StandardConsoleRunnerCallback(false, false, false, false);
                 var log = new TestLog {InputTestFile = "test.js", Message = "hello"};
-                cb.FileLog(log);
+                cb.FileLog(ctx, log);
 
                 Assert.Equal("Log Message: hello from test.js", _out.ToString().Trim());
             }
@@ -49,34 +51,37 @@ namespace Chutzpah.Facts.ConsoleRunner
             [Fact]
             public void It_will_write_file_log_messages_as_standard_out_for_passed_test()
             {
+                var ctx = new TestContext { TaskId = 1 };
                 var cb = new TeamCityConsoleRunnerCallback();
                 var log = new TestLog {InputTestFile = "test.js", Message = "hello"};
                 var result = new TestResult {Passed = true};
                 var tc = new TestCase {TestName = "foo", TestResults = new[] {result}};
-                cb.TestStarted(tc);
-                cb.FileLog(log);
-                cb.TestFinished(tc);
+                cb.TestStarted(ctx, tc);
+                cb.FileLog(ctx, log);
+                cb.TestFinished(ctx, tc);
 
-                Assert.Contains("##teamcity[testStdOut name='foo' out='Log Message: hello from test.js|n|nPassed']", _out.ToString());
+                Assert.Contains($"##teamcity[testStdOut name='foo' flowId='1' out='Log Message: hello from test.js|n|nPassed']", _out.ToString());
             }
 
             [Fact]
             public void It_will_write_file_log_messages_as_standard_out_for_failed_test()
             {
+                var ctx = new TestContext { TaskId = 65 };
                 var cb = new TeamCityConsoleRunnerCallback();
                 var log = new TestLog { InputTestFile = "test.js", Message = "hello" };
                 var result = new TestResult {Passed = false, Message = "failure"};
                 var tc = new TestCase { TestName = "foo", TestResults = new[] { result } };
-                cb.TestStarted(tc);
-                cb.FileLog(log);
-                cb.TestFinished(tc);
+                cb.TestStarted(ctx, tc);
+                cb.FileLog(ctx, log);
+                cb.TestFinished(ctx, tc);
 
-                Assert.Contains("##teamcity[testStdOut name='foo' out='Log Message: hello from test.js|n|nTest |'foo|' failed|n\tfailure|nin  (line 0)|n|n']", _out.ToString());
+                Assert.Contains($"##teamcity[testStdOut name='foo' flowId='65' out='Log Message: hello from test.js|n|nTest |'foo|' failed|n\tfailure|nin  (line 0)|n|n']", _out.ToString());
             }
 
             [Fact]
             public void It_will_separate_file_log_messages_per_test()
             {
+                var ctx = new TestContext { TaskId = 88 };
                 var cb = new TeamCityConsoleRunnerCallback();
                 var log1 = new TestLog {InputTestFile = "test.js", Message = "hello"};
                 var log2 = new TestLog {InputTestFile = "test.js", Message = "world"};
@@ -84,16 +89,16 @@ namespace Chutzpah.Facts.ConsoleRunner
                 var tc1 = new TestCase {TestName = "foo", TestResults = new[] {result}};
                 var tc2 = new TestCase {TestName = "bar", TestResults = new[] {result}};
 
-                cb.TestStarted(tc1);
-                cb.FileLog(log1);
-                cb.TestFinished(tc1);
+                cb.TestStarted(ctx, tc1);
+                cb.FileLog(ctx, log1);
+                cb.TestFinished(ctx, tc1);
 
-                cb.TestStarted(tc2);
-                cb.FileLog(log2);
-                cb.TestFinished(tc2);
+                cb.TestStarted(ctx, tc2);
+                cb.FileLog(ctx, log2);
+                cb.TestFinished(ctx, tc2);
 
-                Assert.Contains("##teamcity[testStdOut name='foo' out='Log Message: hello from test.js|n|nPassed']", _out.ToString());
-                Assert.Contains("##teamcity[testStdOut name='bar' out='Log Message: world from test.js|n|nPassed']", _out.ToString());
+                Assert.Contains($"##teamcity[testStdOut name='foo' flowId='88' out='Log Message: hello from test.js|n|nPassed']", _out.ToString());
+                Assert.Contains($"##teamcity[testStdOut name='bar' flowId='88' out='Log Message: world from test.js|n|nPassed']", _out.ToString());
             }
         }
     }

--- a/Facts/Library/TestCaseStreamReaderFacts.cs
+++ b/Facts/Library/TestCaseStreamReaderFacts.cs
@@ -172,7 +172,7 @@ namespace Chutzpah.Facts
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
-                callback.Verify(x => x.FileStarted("file"));
+                callback.Verify(x => x.FileStarted(context));
             }
 
             [Fact]
@@ -185,7 +185,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestFileSummary result = null;
-                callback.Setup(x => x.FileFinished("file", It.IsAny<TestFileSummary>())).Callback<string, TestFileSummary>((f, t) => result = t); ;
+                callback.Setup(x => x.FileFinished(context, It.IsAny<TestFileSummary>())).Callback<TestContext, TestFileSummary>((c, t) => result = t); ;
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
@@ -204,7 +204,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestCase result = null;
-                callback.Setup(x => x.TestStarted(It.IsAny<TestCase>())).Callback<TestCase>(t => result = t);
+                callback.Setup(x => x.TestStarted(context, It.IsAny<TestCase>())).Callback<TestContext, TestCase>((c, t) => result = t);
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
@@ -224,7 +224,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestCase result = null;
-                callback.Setup(x => x.TestFinished(It.IsAny<TestCase>())).Callback<TestCase>(t => result = t);
+                callback.Setup(x => x.TestFinished(context, It.IsAny<TestCase>())).Callback<TestContext, TestCase>((c, t) => result = t);
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
@@ -244,7 +244,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestLog result = null;
-                callback.Setup(x => x.FileLog(It.IsAny<TestLog>())).Callback<TestLog>(t => result = t);
+                callback.Setup(x => x.FileLog(context, It.IsAny<TestLog>())).Callback<TestContext, TestLog>((c, t) => result = t);
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
@@ -263,7 +263,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestLog result = null;
-                callback.Setup(x => x.FileLog(It.IsAny<TestLog>())).Callback<TestLog>(t => result = t);
+                callback.Setup(x => x.FileLog(context, It.IsAny<TestLog>())).Callback<TestContext, TestLog>((c, t) => result = t);
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
@@ -282,7 +282,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestLog result = null;
-                callback.Setup(x => x.FileLog(It.IsAny<TestLog>())).Callback<TestLog>(t => result = t);
+                callback.Setup(x => x.FileLog(context, It.IsAny<TestLog>())).Callback<TestContext, TestLog>((c, t) => result = t);
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
@@ -299,7 +299,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestError result = null;
-                callback.Setup(x => x.FileError(It.IsAny<TestError>())).Callback<TestError>(t => result = t);
+                callback.Setup(x => x.FileError(context, It.IsAny<TestError>())).Callback<TestContext, TestError>((c, t) => result = t);
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
@@ -472,7 +472,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestCase result = null;
-                callback.Setup(x => x.TestFinished(It.IsAny<TestCase>())).Callback<TestCase>(t => result = t);
+                callback.Setup(x => x.TestFinished(context, It.IsAny<TestCase>())).Callback<TestContext, TestCase>((c, t) => result = t);
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 
@@ -503,7 +503,7 @@ namespace Chutzpah.Facts
                 var processStream = new ProcessStreamStringSource(new Mock<IProcessWrapper>().Object, stream, 1000);
                 var callback = new Mock<ITestMethodRunnerCallback>();
                 TestCase result = null;
-                callback.Setup(x => x.TestFinished(It.IsAny<TestCase>())).Callback<TestCase>(t => result = t);
+                callback.Setup(x => x.TestFinished(It.Is<TestContext>(testContext => testContext == context), It.IsAny<TestCase>())).Callback<TestContext, TestCase>((c, t) => result = t);
 
                 reader.ClassUnderTest.Read(processStream, new TestOptions(), context, callback.Object);
 

--- a/Facts/Library/TestRunnerFacts.cs
+++ b/Facts/Library/TestRunnerFacts.cs
@@ -232,12 +232,11 @@ namespace Chutzpah.Facts
             {
                 var runner = new TestableTestRunner();
                 var testCallback = new MockTestMethodRunnerCallback();
-                var context = runner.SetupTestContext();
                 runner.Mock<IFileProbe>().Setup(x => x.FindFilePath(@"path\tests.html")).Returns(@"D:\path\tests.html");
 
                 TestCaseSummary res = runner.ClassUnderTest.RunTests(@"path\tests.html", testCallback.Object);
 
-                testCallback.Verify(x => x.TestSuiteStarted());
+                testCallback.Verify(x => x.TestSuiteStarted(null));
             }
 
             [Fact]
@@ -245,11 +244,10 @@ namespace Chutzpah.Facts
             {
                 var runner = new TestableTestRunner();
                 var testCallback = new MockTestMethodRunnerCallback();
-                var context = runner.SetupTestContext();
 
                 TestCaseSummary res = runner.ClassUnderTest.RunTests(@"path\tests.html", testCallback.Object);
 
-                testCallback.Verify(x => x.TestSuiteFinished(It.IsAny<TestCaseSummary>()));
+                testCallback.Verify(x => x.TestSuiteFinished(null, It.IsAny<TestCaseSummary>()));
             }
 
 


### PR DESCRIPTION
The issue is caused by running tests in parallel without setting the flowId's of messages in TeamCity's output.

Running tests in parallel can easily cause messages from different threads to be interleaved on the output, which TeamCity can't handle without the use of flowIds.

This PR adds flowIds to TeamCity outputs. This implemented by introducing a ```TaskId``` property on ```TestContext``` and passing it to ```ITestMethodRunnerCallback``` methods, which output the ```TaskId``` as the ```flowId``` in each message.
Two new methods are also needed on the ```ITestMethodRunnerCallback``` interface: ```TestContextStarted``` => flowStarted, ```TestContextFinished``` => flowFinished in order to notify TeamCity about the flows.