### PR TITLE
Escape spaces for runner path in NodeTestExecutionProvider.

### DIFF
--- a/Chutzpah/ChutzpahJSRunners/Chrome/chutzpahRunner.js
+++ b/Chutzpah/ChutzpahJSRunners/Chrome/chutzpahRunner.js
@@ -234,7 +234,7 @@ module.exports.runner = async (onInitialized, onPageLoaded, isFrameworkLoaded, o
     try {
         let chromeExecutable = null;
 
-        if (chromePath == null) {
+        if (!chromePath) {
             const chromePaths = getChromePaths();
             if (chromePaths.length <= 0) {
                 debugLog("Could not find chrome paths");

--- a/Chutzpah/ExecutionProviders/NodeTestExecutionProvider.cs
+++ b/Chutzpah/ExecutionProviders/NodeTestExecutionProvider.cs
@@ -112,7 +112,7 @@ namespace Chutzpah
             string runnerArgs;
             var testModeStr = testExecutionMode.ToString().ToLowerInvariant();
             var timeout = context.TestFileSettings.TestFileTimeout ?? options.TestFileTimeoutMilliseconds ?? Constants.DefaultTestFileTimeout;
-            runnerArgs = string.Format("{0} {1} {2} {3} {4} {5} {6} {7}",
+            runnerArgs = string.Format("\"{0}\" {1} {2} {3} {4} {5} {6} {7}",
                                         runnerPath,
                                         fileUrl,
                                         testModeStr,


### PR DESCRIPTION
When the engine is set to jsdom, tests fail to start when chutzpah.console.exe is in a path that contains spaces. It looks like the runner path argument isn't being escaped in NodeTestExecutionProvider.