### PR TITLE
Add option to inspect node process.

### DIFF
--- a/Chutzpah/ChutzpahJSRunners/JsDom/chutzpahRunner.js
+++ b/Chutzpah/ChutzpahJSRunners/JsDom/chutzpahRunner.js
@@ -1,6 +1,8 @@
 ﻿var module = module || {};
 module.exports = module.exports || {};
 
+const timers = require("timers");
+
 module.exports.runner = async (onInitialized, onPageLoaded, isFrameworkLoaded, onFrameworkLoaded, isTestingDone) => {
 
     const chutzpahCommon = require('../chutzpahFunctions.js');
@@ -246,6 +248,10 @@ module.exports.runner = async (onInitialized, onPageLoaded, isFrameworkLoaded, o
                         return;
                     }
                     window = win;
+
+                    // JSDom doesn't define these but we can use the global ones Node gives us.
+                    window.setTimeout = timers.setTimeout;
+                    window.setImmediate = timers.setImmediate;
 
                     debugLog("Setup stubs for JsDom");
                     window.eval(`

--- a/Chutzpah/ExecutionProviders/NodeTestExecutionProvider.cs
+++ b/Chutzpah/ExecutionProviders/NodeTestExecutionProvider.cs
@@ -112,7 +112,9 @@ namespace Chutzpah
             string runnerArgs;
             var testModeStr = testExecutionMode.ToString().ToLowerInvariant();
             var timeout = context.TestFileSettings.TestFileTimeout ?? options.TestFileTimeoutMilliseconds ?? Constants.DefaultTestFileTimeout;
-            runnerArgs = string.Format("\"{0}\" {1} {2} {3} {4} {5} {6} {7}",
+            string inspectBrkArg = context.TestFileSettings.EngineOptions.NodeInspect ? "--inspect-brk" : "";
+            runnerArgs = string.Format("{0} \"{1}\" {2} {3} {4} {5} {6} {7} {8}",
+                                        inspectBrkArg,
                                         runnerPath,
                                         fileUrl,
                                         testModeStr,

--- a/Chutzpah/Models/ChutzpahTestSettingsFile.cs
+++ b/Chutzpah/Models/ChutzpahTestSettingsFile.cs
@@ -56,6 +56,11 @@ namespace Chutzpah.Models
         /// The path to the chrome/chromium executable on the machine
         /// </summary>
         public string ChromeBrowserPath { get; set; }
+
+        /// <summary>
+        /// Whether or not to execute node with remote debugging enabled.
+        /// </summary>
+        public bool NodeInspect { get; set; }
     }
 
     public class ForcedChutzpahWebServerConfiguration : ChutzpahWebServerConfiguration


### PR DESCRIPTION
A corresponding update should be made to the wiki to document the new option EngineOptions.NodeInspect.

When NodeInspect is true, the first argument to the node.exe process will be `--inspect-brk`, which allows a remote debugger to connect to localhost:9229. Furthermore, the debugger will break at the first line of execution, meaning the test will not proceed until the user has opened the debugger and continued the script.

The easiest way to do this is open Chrome and go to about:inspect. Once the node.exe process is started, there will be a Remote Target listed, similar to this:
![image](https://user-images.githubusercontent.com/397836/56671045-e462b800-6681-11e9-8a58-168475191563.png)

Just click Inspect to open the debugger.

Maybe: disable the TestFileTimeout when this option is used?