### PR TITLE
Imporve build

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -14,7 +14,7 @@ properties {
   # Temp work around psake limitation to not use Msbuild 15
   $defaultMSBuildPath = Join-Path (Resolve-Path "${env:ProgramFiles(x86)}") "Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
   if($env:Chutzpah_MSBuild_Path -and (Test-Path $env:Chutzpah_MSBuild_Path)) {
-    $msbuild = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
+    $msbuild = Join-Path (Resolve-Path "${env:Chutzpah_MSBuild_Path}") "MSBuild.exe"
   } 
   elseif (Test-Path $defaultMSBuildPath) {
     $msbuild = $defaultMSBuildPath

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+        <!--
+            Used to specify the default location to expand packages.
+            See: nuget.exe help install
+            See: nuget.exe help update
+
+            In this example, %PACKAGEHOME% is an environment variable. On Mac/Linux,
+            use $PACKAGE_HOME/External as the value.
+        -->
+        <add key="repositoryPath" value="$\..\packages" />
+    </config>
+
+    <packageRestore>
+        <!-- Allow NuGet to download missing packages -->
+        <add key="enabled" value="True" />
+
+        <!-- Automatically check for missing packages during build in Visual Studio -->
+        <add key="automatic" value="True" />
+    </packageRestore>
+
+    <!--
+        Used to specify the default Sources for list, install and update.
+        See: nuget.exe help list
+        See: nuget.exe help install
+        See: nuget.exe help update
+    -->
+    <packageSources>
+        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+
+    <!--
+        Used to specify trusted signers to allow during signature verification.
+        See: nuget.exe help trusted-signers
+    -->
+    <trustedSigners>
+        <author name="microsoft">
+            <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+        </author>
+        <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+            <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+            <owners>microsoft;aspnet;nuget</owners>
+        </repository>
+    </trustedSigners>
+</configuration>


### PR DESCRIPTION
After I pulled the repository for the first time. I had issues to build it.

- Your machine nuget source get in a way 
  Fixed by introducing nuget.config that points to nuget.org only to search for packages primarily there
- The environment variable Chutzpah_MSBuild_Path was never used in the build