### PR TITLE
Disable CORS by default

### DIFF
--- a/Chutzpah/ChutzpahJSRunners/Chrome/chutzpahRunner.js
+++ b/Chutzpah/ChutzpahJSRunners/Chrome/chutzpahRunner.js
@@ -250,8 +250,12 @@ module.exports.runner = async (onInitialized, onPageLoaded, isFrameworkLoaded, o
         chutzpahFunctions.rawLog("!!_!! Using Chrome Install : " + chromeExecutable);
         debugLog("Launch Chrome (" + chromeExecutable + "): Elevated= " + isRunningElevated);
 
+        // Disable CORS by default
+        var launchBrowserArges = ["--disable-web-security"];
         // If isRunningElevated, we need to turn off sandbox since it does not work with admin users
-        var launchBrowserArges = isRunningElevated ? ["--no-sandbox"] : [];
+        if (isRunningElevated) {
+            launchBrowserArges.push("--no-sandbox");
+        }
         if (browserArgs) {
             launchBrowserArges.push(...browserArgs.trim().split(" "));
         }


### PR DESCRIPTION
Disable CORS by default in Chrome runner to enable running tests in Headless Chrome which utilize AJAX requests. This is consistent to the behavior when running tests with PhantomJS as target engine.