### PR TITLE
Move 'browser' variable to outer scope

### DIFF
--- a/Chutzpah/ChutzpahJSRunners/Chrome/chutzpahRunner.js
+++ b/Chutzpah/ChutzpahJSRunners/Chrome/chutzpahRunner.js
@@ -17,7 +17,8 @@ module.exports.runner = async (onInitialized, onPageLoaded, isFrameworkLoaded, o
         finalResult = 0,
         isRunningElevated = false,
         chromePath = null,
-        browserArgs = null;
+        browserArgs = null,
+        browser = null;
 
     startTime = new Date().getTime();
 
@@ -262,7 +263,7 @@ module.exports.runner = async (onInitialized, onPageLoaded, isFrameworkLoaded, o
         chutzpahFunctions.rawLog("!!_!! puppeteer browser args: " + JSON.stringify(launchBrowserArges));
 
         // If isRunningElevated, we need to turn off sandbox since it does not work with admin users
-        const browser = await puppeteer.launch({
+        browser = await puppeteer.launch({
                 headless: true, args: launchBrowserArges, executablePath: chromeExecutable
             });
 


### PR DESCRIPTION
The browser variable is declared in the inner scope of a try-catch block.

There are [references](https://github.com/mmanela/chutzpah/blob/6fb2df4ec43000dfcf51808c71383e11b0cec585/Chutzpah/ChutzpahJSRunners/Chrome/chutzpahRunner.js#L342) to this variable outside that block which may lead to a 'variable not defined'.

This leads to an issue when the execution of a test file exceeds the configured timeout. In this case the chutpah.console.exe will terminate with a generic 'exit code 2' from the [general error handler in the qunitRunner.js component](https://github.com/mmanela/chutzpah/blob/6fb2df4ec43000dfcf51808c71383e11b0cec585/Chutzpah/ChutzpahJSRunners/Chrome/qunitRunner.js#L21) instead of the intended timeout error.